### PR TITLE
Fix login token storage and cleanup AppModule

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,19 +4,16 @@ import { ConfigModule } from '@nestjs/config';
 import { typeOrmConfig } from './config/typeorm.config';
 import { PlayersModule } from './modules/players/players.module';
 import { AuthModule } from './modules/auth/auth.module';
+
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRoot(typeOrmConfig),
     PlayersModule,
-  ],
-  controllers: [],
-  providers: [],
-})
-@Module({
-  imports: [
     AuthModule,
     /* … otros módulos */
   ],
+  controllers: [],
+  providers: [],
 })
 export class AppModule {}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -35,7 +35,8 @@ export default function Login() {
         password,
       })
 
-      localStorage.setItem("token", res.data.token)
+      // Store the JWT from `accessToken` returned by the backend
+      localStorage.setItem("token", res.data.accessToken)
       toast.success("Inicio de sesión exitoso")
       navigate("/dashboard")
     } catch (err) {

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -10,7 +10,8 @@ export async function login(email: string, password: string) {
   if (!res.ok) throw new Error("Login failed");
 
   const data = await res.json();
-  localStorage.setItem("token", data.token);
+  // The backend returns the JWT as `accessToken`
+  localStorage.setItem("token", data.accessToken);
   return data;
 }
 


### PR DESCRIPTION
## Summary
- wire AuthModule into NestJS application
- fix login token handling in React login page and authService

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` in backend *(fails: jest not found)*
- `npm run lint` in frontend *(fails: cannot find package '@eslint/js')*
- `npm test` in frontend *(fails: missing test script)*