### PR TITLE
Implement players CRUD and skeleton modules

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,8 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,22 +1,22 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeOrmConfig } from './config/typeorm.config';
-import { PlayersModule } from './modules/players/players.module';
 import { AuthModule } from './modules/auth/auth.module';
+import { PlayersModule } from './modules/players/players.module';
+import { FormationsModule } from './modules/formations/formations.module';
+import { MatchesModule } from './modules/matches/matches.module';
+import { IaModule } from './modules/ia/ia.module';
+
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     TypeOrmModule.forRoot(typeOrmConfig),
-    PlayersModule,
-  ],
-  controllers: [],
-  providers: [],
-})
-@Module({
-  imports: [
     AuthModule,
-    /* … otros módulos */
+    PlayersModule,
+    FormationsModule,
+    MatchesModule,
+    IaModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/formations/formation.entity.ts
+++ b/backend/src/modules/formations/formation.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('formation')
+export class Formation {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  name!: string;
+}

--- a/backend/src/modules/formations/formations.controller.ts
+++ b/backend/src/modules/formations/formations.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('formations')
+export class FormationsController {}

--- a/backend/src/modules/formations/formations.module.ts
+++ b/backend/src/modules/formations/formations.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Formation } from './formation.entity';
+import { FormationsService } from './formations.service';
+import { FormationsController } from './formations.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Formation])],
+  providers: [FormationsService],
+  controllers: [FormationsController],
+  exports: [FormationsService],
+})
+export class FormationsModule {}

--- a/backend/src/modules/formations/formations.service.ts
+++ b/backend/src/modules/formations/formations.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class FormationsService {}

--- a/backend/src/modules/ia/ia.controller.ts
+++ b/backend/src/modules/ia/ia.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('ia')
+export class IaController {}

--- a/backend/src/modules/ia/ia.entity.ts
+++ b/backend/src/modules/ia/ia.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('ia_task')
+export class IaTask {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  description!: string;
+}

--- a/backend/src/modules/ia/ia.module.ts
+++ b/backend/src/modules/ia/ia.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IaTask } from './ia.entity';
+import { IaService } from './ia.service';
+import { IaController } from './ia.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([IaTask])],
+  providers: [IaService],
+  controllers: [IaController],
+  exports: [IaService],
+})
+export class IaModule {}

--- a/backend/src/modules/ia/ia.service.ts
+++ b/backend/src/modules/ia/ia.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class IaService {}

--- a/backend/src/modules/matches/match.entity.ts
+++ b/backend/src/modules/matches/match.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('match')
+export class Match {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  rival!: string;
+}

--- a/backend/src/modules/matches/matches.controller.ts
+++ b/backend/src/modules/matches/matches.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('matches')
+export class MatchesController {}

--- a/backend/src/modules/matches/matches.module.ts
+++ b/backend/src/modules/matches/matches.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Match } from './match.entity';
+import { MatchesService } from './matches.service';
+import { MatchesController } from './matches.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Match])],
+  providers: [MatchesService],
+  controllers: [MatchesController],
+  exports: [MatchesService],
+})
+export class MatchesModule {}

--- a/backend/src/modules/matches/matches.service.ts
+++ b/backend/src/modules/matches/matches.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MatchesService {}

--- a/backend/src/modules/players/dto/create-player.dto.ts
+++ b/backend/src/modules/players/dto/create-player.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsOptional, IsNumber } from 'class-validator';
+
+export class CreatePlayerDto {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsNumber()
+  score?: number;
+}

--- a/backend/src/modules/players/dto/update-player.dto.ts
+++ b/backend/src/modules/players/dto/update-player.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsOptional, IsNumber } from 'class-validator';
+
+export class UpdatePlayerDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsNumber()
+  score?: number;
+}

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -1,4 +1,31 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Param, Body, UseGuards } from '@nestjs/common';
+import { PlayersService } from './players.service';
+import { CreatePlayerDto } from './dto/create-player.dto';
+import { UpdatePlayerDto } from './dto/update-player.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
+@UseGuards(JwtAuthGuard)
 @Controller('players')
-export class PlayersController {}
+export class PlayersController {
+  constructor(private playersService: PlayersService) {}
+
+  @Get()
+  findAll() {
+    return this.playersService.findAll();
+  }
+
+  @Post()
+  create(@Body() body: CreatePlayerDto) {
+    return this.playersService.create(body);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() body: UpdatePlayerDto) {
+    return this.playersService.update(id, body);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.playersService.remove(id);
+  }
+}

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -1,4 +1,36 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Player } from './player.entity';
+import { CreatePlayerDto } from './dto/create-player.dto';
+import { UpdatePlayerDto } from './dto/update-player.dto';
 
 @Injectable()
-export class PlayersService {}
+export class PlayersService {
+  constructor(@InjectRepository(Player) private repo: Repository<Player>) {}
+
+  create(data: CreatePlayerDto) {
+    const player = this.repo.create(data);
+    return this.repo.save(player);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+
+  async findOne(id: string) {
+    const player = await this.repo.findOne({ where: { id } });
+    if (!player) throw new NotFoundException('Player not found');
+    return player;
+  }
+
+  async update(id: string, data: UpdatePlayerDto) {
+    await this.repo.update(id, data);
+    return this.findOne(id);
+  }
+
+  async remove(id: string) {
+    const result = await this.repo.delete(id);
+    if (result.affected === 0) throw new NotFoundException('Player not found');
+  }
+}

--- a/ia-service/app/main.py
+++ b/ia-service/app/main.py
@@ -1,7 +1,15 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 
 app = FastAPI()
 
 @app.get("/")
 async def root():
     return {"message": "Hello from FastAPI"}
+
+@app.post("/ia/suggest_lineup", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+async def suggest_lineup():
+    return {"detail": "Not implemented"}
+
+@app.post("/ia/analyze_performance", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+async def analyze_performance():
+    return {"detail": "Not implemented"}


### PR DESCRIPTION
## Summary
- add player DTOs and implement players service CRUD
- add players controller endpoints protected by JWT
- create skeleton modules for formations, matches and ia
- update AppModule to include new modules
- stub IA service endpoints
- include class-validator dependencies

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definitions)*