### PR TITLE
Fix password env var and enforce JWT_SECRET

### DIFF
--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -12,7 +12,13 @@ import { JwtStrategy } from './jwt.strategy';
     TypeOrmModule.forFeature([User]),
     PassportModule,
     JwtModule.register({
-      secret: process.env.JWT_SECRET || 'secret',
+      secret: (() => {
+        const jwtSecret = process.env.JWT_SECRET;
+        if (!jwtSecret) {
+          throw new Error('JWT_SECRET environment variable is required');
+        }
+        return jwtSecret;
+      })(),
       signOptions: { expiresIn: '1h' },
     }),
   ],

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: infra-postgres-1
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: OjoPezGato1!
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: sandeidb
     ports:
       - "5432:5432"


### PR DESCRIPTION
## Summary
- use `POSTGRES_PASSWORD` from environment in the infra compose file
- ensure `JWT_SECRET` is provided for the auth module

## Testing
- `npm test` *(fails: jest not found)*