### PR TITLE
Implement DTO validations and IA endpoints

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
   const port = process.env.BACKEND_PORT || 3000;
   await app.listen(port);
   console.log(`🚀 Backend listening on port ${port}`);

--- a/backend/src/modules/players/dto/create-player.dto.ts
+++ b/backend/src/modules/players/dto/create-player.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsOptional, IsNumber } from 'class-validator';
+
+export class CreatePlayerDto {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsNumber()
+  score?: number;
+}

--- a/backend/src/modules/players/dto/update-player.dto.ts
+++ b/backend/src/modules/players/dto/update-player.dto.ts
@@ -1,0 +1,17 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePlayerDto } from './create-player.dto';
+import { IsOptional, IsString, IsNumber } from 'class-validator';
+
+export class UpdatePlayerDto extends PartialType(CreatePlayerDto) {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsNumber()
+  score?: number;
+}

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -6,11 +6,12 @@ import {
   Delete,
   Body,
   Param,
-  BadRequestException,
   NotFoundException,
   ParseUUIDPipe,
 } from '@nestjs/common';
 import { PlayersService } from './players.service';
+import { CreatePlayerDto } from './dto/create-player.dto';
+import { UpdatePlayerDto } from './dto/update-player.dto';
 
 @Controller('players')
 export class PlayersController {
@@ -22,17 +23,14 @@ export class PlayersController {
   }
 
   @Post()
-  create(
-    @Body() body: { name: string; position?: string; score?: number },
-  ) {
-    if (!body.name) throw new BadRequestException('name is required');
+  create(@Body() body: CreatePlayerDto) {
     return this.playersService.create(body);
   }
 
   @Put(':id')
   async update(
     @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
-    @Body() body: { name?: string; position?: string; score?: number },
+    @Body() body: UpdatePlayerDto,
   ) {
     const player = await this.playersService.update(id, body);
     if (!player) throw new NotFoundException('Player not found');

--- a/ia-service/app/main.py
+++ b/ia-service/app/main.py
@@ -1,7 +1,17 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, status
 
 app = FastAPI()
 
 @app.get("/")
 async def root():
     return {"message": "Hello from FastAPI"}
+
+
+@app.post("/ia/suggest_lineup")
+async def suggest_lineup():
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED)
+
+
+@app.post("/ia/analyze_performance")
+async def analyze_performance():
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED)


### PR DESCRIPTION
## Summary
- add DTOs for players with class-validator
- update players controller to use DTOs
- enable global ValidationPipe
- stub IA service endpoints for future implementation

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: command not found)*
- `npm run build` in frontend *(fails: missing dependencies)*