### PR TITLE
Implement ratings and IA analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ Gestión de jugadores:
 - Validaciones con class-validator
 - Hook usePlayers() en frontend con integración a la API
 - Gestión de formaciones con endpoints protegidos
+- Registro de calificaciones por jugador
 
 Servicio de IA:
 
 - Servicio REST en FastAPI preparado para integrar funcionalidades de análisis inteligente
 - Módulo IA en el backend para futuras integraciones
+- Endpoint `/ia/analyze_performance` para evaluar el rendimiento según las calificaciones
 
 ---
 

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/backend/src/migrations/1747088295097-CreateMatchesTable.ts
+++ b/backend/src/migrations/1747088295097-CreateMatchesTable.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateMatchesTable1747088295097 implements MigrationInterface {
+    name = 'CreateMatchesTable1747088295097'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "match" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "date" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_match_id" PRIMARY KEY ("id"))`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "match"`);
+    }
+}

--- a/backend/src/migrations/1747088295098-CreateRatingsTable.ts
+++ b/backend/src/migrations/1747088295098-CreateRatingsTable.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateRatingsTable1747088295098 implements MigrationInterface {
+    name = 'CreateRatingsTable1747088295098'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "rating" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "score" integer NOT NULL, "comment" character varying, "playerId" uuid, "matchId" uuid, CONSTRAINT "PK_rating_id" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "rating" ADD CONSTRAINT "FK_rating_player" FOREIGN KEY ("playerId") REFERENCES "player"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "rating" ADD CONSTRAINT "FK_rating_match" FOREIGN KEY ("matchId") REFERENCES "match"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "rating" DROP CONSTRAINT "FK_rating_match"`);
+        await queryRunner.query(`ALTER TABLE "rating" DROP CONSTRAINT "FK_rating_player"`);
+        await queryRunner.query(`DROP TABLE "rating"`);
+    }
+}

--- a/backend/src/modules/ratings/dto/create-rating.dto.ts
+++ b/backend/src/modules/ratings/dto/create-rating.dto.ts
@@ -1,0 +1,15 @@
+import { IsUUID, IsInt, Min, Max, IsOptional, IsString } from 'class-validator';
+
+export class CreateRatingDto {
+  @IsUUID()
+  playerId!: string;
+
+  @IsInt()
+  @Min(0)
+  @Max(10)
+  score!: number;
+
+  @IsOptional()
+  @IsString()
+  comment?: string;
+}

--- a/backend/src/modules/ratings/ratings.controller.ts
+++ b/backend/src/modules/ratings/ratings.controller.ts
@@ -1,14 +1,24 @@
-import { Body, Controller, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Param,
+  Post,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreateRatingDto } from './dto/create-rating.dto';
 import { RatingsService } from './ratings.service';
 
 @Controller('matches/:matchId/ratings')
 export class RatingsController {
   constructor(private readonly ratingsService: RatingsService) {}
 
+  @UseGuards(JwtAuthGuard)
   @Post()
   async create(
-    @Param('matchId') matchId: string,
-    @Body() body: { playerId: string; score: number; comment?: string },
+    @Param('matchId', new ParseUUIDPipe({ version: '4' })) matchId: string,
+    @Body() body: CreateRatingDto,
   ) {
     return this.ratingsService.create(matchId, body.playerId, body.score, body.comment);
   }

--- a/backend/src/modules/ratings/ratings.service.spec.ts
+++ b/backend/src/modules/ratings/ratings.service.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RatingsService } from './ratings.service';
+import { Rating } from './rating.entity';
+import { Match } from '../matches/match.entity';
+import { Player } from '../players/player.entity';
+
+describe('RatingsService', () => {
+  let service: RatingsService;
+  let ratingsRepo: Repository<Rating>;
+  let matchesRepo: Repository<Match>;
+  let playersRepo: Repository<Player>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RatingsService,
+        {
+          provide: getRepositoryToken(Rating),
+          useValue: { create: jest.fn(), save: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(Match),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(Player),
+          useValue: { findOne: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RatingsService>(RatingsService);
+    ratingsRepo = module.get(getRepositoryToken(Rating));
+    matchesRepo = module.get(getRepositoryToken(Match));
+    playersRepo = module.get(getRepositoryToken(Player));
+  });
+
+  it('creates a rating', async () => {
+    const match = { id: 'm1' } as Match;
+    const player = { id: 'p1' } as Player;
+    (matchesRepo.findOne as jest.Mock).mockResolvedValue(match);
+    (playersRepo.findOne as jest.Mock).mockResolvedValue(player);
+    (ratingsRepo.create as jest.Mock).mockReturnValue({ score: 8, match, player });
+    (ratingsRepo.save as jest.Mock).mockResolvedValue({ id: 'r1' });
+
+    const result = await service.create('m1', 'p1', 8, 'good');
+    expect(ratingsRepo.create).toHaveBeenCalledWith({ score: 8, comment: 'good', match, player });
+    expect(ratingsRepo.save).toHaveBeenCalled();
+    expect(result).toEqual({ id: 'r1' });
+  });
+});

--- a/ia-service/app/main.py
+++ b/ia-service/app/main.py
@@ -1,4 +1,16 @@
 from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel
+from typing import List, Optional
+import os
+
+try:
+    import openai
+except Exception:  # pragma: no cover - openai may not be installed
+    openai = None
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if openai and OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
 
 app = FastAPI()
 
@@ -12,6 +24,35 @@ async def suggest_lineup():
     raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED)
 
 
+class Rating(BaseModel):
+    player: str
+    score: int
+    comment: Optional[str] = None
+
+
+class PerformanceRequest(BaseModel):
+    ratings: List[Rating]
+
+
 @app.post("/ia/analyze_performance")
-async def analyze_performance():
-    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED)
+async def analyze_performance(payload: PerformanceRequest):
+    if not openai:
+        raise HTTPException(status_code=500, detail="OpenAI not available")
+
+    prompt = "\n".join(
+        [f'{r.player}: {r.score} - {r.comment or ""}' for r in payload.ratings]
+    )
+
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "Analyze team performance"},
+                {"role": "user", "content": prompt},
+            ],
+            timeout=30,
+        )
+        analysis = resp.choices[0].message.content
+        return {"analysis": analysis}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/ia-service/requirements.txt
+++ b/ia-service/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+openai

--- a/ia-service/tests/test_analyze_performance.py
+++ b/ia-service/tests/test_analyze_performance.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+import types
+import sys
+
+from app.main import app
+
+client = TestClient(app)
+
+class FakeChatCompletion:
+    @staticmethod
+    def create(**kwargs):
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))])
+
+
+def test_analyze_performance(monkeypatch):
+    fake_openai = types.SimpleNamespace(ChatCompletion=FakeChatCompletion)
+    monkeypatch.setitem(sys.modules, 'openai', fake_openai)
+    response = client.post(
+        "/ia/analyze_performance",
+        json={"ratings": [{"player": "John", "score": 7}]},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"analysis": "ok"}


### PR DESCRIPTION
## Summary
- add `CreateRatingDto` with validations
- secure ratings controller and use DTO
- create database migrations for matches and ratings tables
- provide Jest config and service test for ratings
- implement `/ia/analyze_performance` endpoint using OpenAI
- include openai in requirements and add pytest for IA service
- document new post-match features in README

## Testing
- `npm test` *(fails: jest not installed)*
- `pytest -q` *(fails: pytest not installed)*