### PR TITLE
Add unit tests and frontend testing setup

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,4 +22,5 @@ jobs:
       - run: npm ci
       - run: npx eslint .
       - run: npx prettier --check .
+      - run: npm run test -- --run
       - run: npm run build

--- a/backend/src/modules/formations/__tests__/formations.controller.spec.ts
+++ b/backend/src/modules/formations/__tests__/formations.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { FormationsController } from '../formations.controller';
+import { FormationsService } from '../formations.service';
+
+describe('FormationsController', () => {
+  let controller: FormationsController;
+  let service: FormationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FormationsController],
+      providers: [
+        {
+          provide: FormationsService,
+          useValue: {
+            findAll: jest.fn(),
+            findById: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<FormationsController>(FormationsController);
+    service = module.get<FormationsService>(FormationsService);
+  });
+
+  it('throws NotFoundException when formation not found', async () => {
+    (service.update as jest.Mock).mockResolvedValue(null);
+    await expect(controller.update('x', {})).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('calls service to create a formation', () => {
+    controller.create({ name: 'test' } as any);
+    expect(service.create).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/formations/__tests__/formations.service.spec.ts
+++ b/backend/src/modules/formations/__tests__/formations.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FormationsService } from '../formations.service';
+import { Formation } from '../formation.entity';
+
+describe('FormationsService', () => {
+  let service: FormationsService;
+  let repo: Repository<Formation>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FormationsService,
+        {
+          provide: getRepositoryToken(Formation),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<FormationsService>(FormationsService);
+    repo = module.get(getRepositoryToken(Formation));
+  });
+
+  it('creates a formation', async () => {
+    const data = { name: '4-4-2' } as Partial<Formation>;
+    (repo.create as jest.Mock).mockReturnValue(data);
+    (repo.save as jest.Mock).mockResolvedValue({ id: '1', ...data });
+
+    const result = await service.create(data);
+    expect(repo.create).toHaveBeenCalledWith(data);
+    expect(repo.save).toHaveBeenCalledWith(data);
+    expect(result).toEqual({ id: '1', ...data });
+  });
+
+  it('removes a formation if found', async () => {
+    const formation = { id: '1' } as Formation;
+    (repo.findOne as jest.Mock).mockResolvedValue(formation);
+    await service.remove('1');
+    expect(repo.remove).toHaveBeenCalledWith(formation);
+  });
+
+  it('returns null when removing missing formation', async () => {
+    (repo.findOne as jest.Mock).mockResolvedValue(null);
+    const result = await service.remove('x');
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/modules/matches/__tests__/matches.controller.spec.ts
+++ b/backend/src/modules/matches/__tests__/matches.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { MatchesController } from '../matches.controller';
+import { MatchesService } from '../matches.service';
+
+describe('MatchesController', () => {
+  let controller: MatchesController;
+  let service: MatchesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MatchesController],
+      providers: [
+        {
+          provide: MatchesService,
+          useValue: {
+            findAll: jest.fn(),
+            findById: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<MatchesController>(MatchesController);
+    service = module.get<MatchesService>(MatchesService);
+  });
+
+  it('throws NotFoundException when match not found', async () => {
+    (service.findById as jest.Mock).mockResolvedValue(null);
+    await expect(controller.findOne('x')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('calls service to create a match', () => {
+    controller.create({} as any);
+    expect(service.create).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/matches/__tests__/matches.service.spec.ts
+++ b/backend/src/modules/matches/__tests__/matches.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MatchesService } from '../matches.service';
+import { Match } from '../match.entity';
+
+describe('MatchesService', () => {
+  let service: MatchesService;
+  let repo: Repository<Match>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MatchesService,
+        {
+          provide: getRepositoryToken(Match),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MatchesService>(MatchesService);
+    repo = module.get(getRepositoryToken(Match));
+  });
+
+  it('creates a match', async () => {
+    const data = { location: 'A' } as Partial<Match>;
+    (repo.create as jest.Mock).mockReturnValue(data);
+    (repo.save as jest.Mock).mockResolvedValue({ id: '1', ...data });
+
+    const result = await service.create(data);
+    expect(repo.create).toHaveBeenCalledWith(data);
+    expect(repo.save).toHaveBeenCalledWith(data);
+    expect(result).toEqual({ id: '1', ...data });
+  });
+
+  it('removes a match if found', async () => {
+    const match = { id: '1' } as Match;
+    (repo.findOne as jest.Mock).mockResolvedValue(match);
+    await service.remove('1');
+    expect(repo.remove).toHaveBeenCalledWith(match);
+  });
+
+  it('returns null when removing missing match', async () => {
+    (repo.findOne as jest.Mock).mockResolvedValue(null);
+    const result = await service.remove('nope');
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/modules/players/__tests__/players.controller.spec.ts
+++ b/backend/src/modules/players/__tests__/players.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { PlayersController } from '../players.controller';
+import { PlayersService } from '../players.service';
+
+describe('PlayersController', () => {
+  let controller: PlayersController;
+  let service: PlayersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PlayersController],
+      providers: [
+        {
+          provide: PlayersService,
+          useValue: {
+            findAll: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<PlayersController>(PlayersController);
+    service = module.get<PlayersService>(PlayersService);
+  });
+
+  it('throws NotFoundException when player not found', async () => {
+    (service.findOne as jest.Mock).mockResolvedValue(null);
+    await expect(controller.findOne('x')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('calls service to create a player', () => {
+    controller.create({ name: 'test' } as any);
+    expect(service.create).toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/players/__tests__/players.service.spec.ts
+++ b/backend/src/modules/players/__tests__/players.service.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PlayersService } from '../players.service';
+import { Player } from '../player.entity';
+
+describe('PlayersService', () => {
+  let service: PlayersService;
+  let repo: Repository<Player>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlayersService,
+        {
+          provide: getRepositoryToken(Player),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PlayersService>(PlayersService);
+    repo = module.get(getRepositoryToken(Player));
+  });
+
+  it('creates a player', async () => {
+    const data = { name: 'John' } as Partial<Player>;
+    (repo.create as jest.Mock).mockReturnValue(data);
+    (repo.save as jest.Mock).mockResolvedValue({ id: '1', ...data });
+
+    const result = await service.create(data);
+    expect(repo.create).toHaveBeenCalledWith(data);
+    expect(repo.save).toHaveBeenCalledWith(data);
+    expect(result).toEqual({ id: '1', ...data });
+  });
+
+  it('removes a player if found', async () => {
+    const player = { id: '1' } as Player;
+    (repo.findOne as jest.Mock).mockResolvedValue(player);
+    await service.remove('1');
+    expect(repo.remove).toHaveBeenCalledWith(player);
+  });
+
+  it('returns null when removing missing player', async () => {
+    (repo.findOne as jest.Mock).mockResolvedValue(null);
+    const result = await service.remove('nope');
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.2",
@@ -39,6 +40,10 @@
     "tw-animate-css": "^1.2.9",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.0.0",
+    "jsdom": "^23.0.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.3.1"
   }
 }

--- a/frontend/src/components/PrivateRoute.spec.tsx
+++ b/frontend/src/components/PrivateRoute.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PrivateRoute from './PrivateRoute'
+import * as authService from '@/services/authService'
+
+vi.mock('@/services/authService')
+
+describe('PrivateRoute', () => {
+  it('renders children when authenticated', () => {
+    (authService.isAuthenticated as jest.Mock).mockReturnValue(true)
+    render(
+      <MemoryRouter>
+        <PrivateRoute>
+          <div>Secret</div>
+        </PrivateRoute>
+      </MemoryRouter>
+    )
+    expect(screen.getByText('Secret')).toBeInTheDocument()
+  })
+
+  it('does not render children when unauthenticated', () => {
+    (authService.isAuthenticated as jest.Mock).mockReturnValue(false)
+    render(
+      <MemoryRouter initialEntries={['/secret']}>
+        <PrivateRoute>
+          <div>Secret</div>
+        </PrivateRoute>
+      </MemoryRouter>
+    )
+    expect(screen.queryByText('Secret')).toBeNull()
+  })
+})

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,7 +18,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "types": ["vitest/globals"]
   },
   "include": ["src"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
 import path from "path"
+import { configDefaults } from "vitest/config"
 
 export default defineConfig({
   plugins: [react()],
@@ -8,6 +9,11 @@ export default defineConfig({
     alias: {
       "@": path.resolve(path.dirname(new URL(import.meta.url).pathname), "./src"),
     },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    exclude: [...configDefaults.exclude, "e2e/**"],
   },
 })
 


### PR DESCRIPTION
## Summary
- add Jest service and controller tests for players, matches and formations modules
- configure React testing with Vitest and add a PrivateRoute test
- run frontend tests in the CI workflow

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test -- --run` in frontend *(fails: vitest not found)*