### PR TITLE
Implement IA HTTP module

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 BACKEND_PORT=3000
 DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
 JWT_SECRET=supersecret
+IA_SERVICE_URL=http://localhost:8000

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,8 @@
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "@nestjs/axios": "^11.1.0"
   },
   "devDependencies": {
     "@nestjs/testing": "^11.1.0",
@@ -45,6 +46,7 @@
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typeorm": "^0.3.23"
+    "typeorm": "^0.3.23",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/src/modules/ia/dto/lineup-request.dto.ts
+++ b/backend/src/modules/ia/dto/lineup-request.dto.ts
@@ -1,0 +1,11 @@
+import { IsArray, ArrayNotEmpty, IsString } from 'class-validator';
+
+export class LineupRequestDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  players!: string[];
+
+  @IsString()
+  formation!: string;
+}

--- a/backend/src/modules/ia/dto/lineup-response.dto.ts
+++ b/backend/src/modules/ia/dto/lineup-response.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class LineupResponseDto {
+  @IsString()
+  lineup!: string;
+}

--- a/backend/src/modules/ia/ia.controller.spec.ts
+++ b/backend/src/modules/ia/ia.controller.spec.ts
@@ -1,0 +1,45 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, HttpStatus } from '@nestjs/common';
+import { IaModule } from './ia.module';
+import { HttpService } from '@nestjs/axios';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { of } from 'rxjs';
+import { AxiosResponse } from 'axios';
+import * as request from 'supertest';
+
+describe('IaController', () => {
+  let app: INestApplication;
+  let httpService: HttpService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [IaModule],
+    })
+      .overrideProvider(HttpService)
+      .useValue({ post: jest.fn() })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    httpService = moduleRef.get<HttpService>(HttpService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /ia/suggest_lineup', () => {
+    const data = { lineup: 'ok' };
+    (httpService.post as jest.Mock).mockReturnValue(
+      of({ data } as AxiosResponse),
+    );
+    return request(app.getHttpServer())
+      .post('/ia/suggest_lineup')
+      .send({ players: ['x'], formation: '4-4-2' })
+      .expect(HttpStatus.CREATED)
+      .expect(data);
+  });
+});

--- a/backend/src/modules/ia/ia.controller.ts
+++ b/backend/src/modules/ia/ia.controller.ts
@@ -1,4 +1,16 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { IaService } from './ia.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { LineupRequestDto } from './dto/lineup-request.dto';
+import { LineupResponseDto } from './dto/lineup-response.dto';
 
 @Controller('ia')
-export class IaController {}
+export class IaController {
+  constructor(private readonly iaService: IaService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post('suggest_lineup')
+  suggestLineup(@Body() body: LineupRequestDto): Promise<LineupResponseDto> {
+    return this.iaService.suggestLineup(body.players, body.formation);
+  }
+}

--- a/backend/src/modules/ia/ia.module.ts
+++ b/backend/src/modules/ia/ia.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { IaService } from './ia.service';
 import { IaController } from './ia.controller';
 
 @Module({
+  imports: [
+    HttpModule.register({
+      baseURL: process.env.IA_SERVICE_URL || 'http://localhost:8000',
+    }),
+  ],
   providers: [IaService],
   controllers: [IaController],
 })

--- a/backend/src/modules/ia/ia.service.spec.ts
+++ b/backend/src/modules/ia/ia.service.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpModule, HttpService } from '@nestjs/axios';
+import { IaService } from './ia.service';
+import { of } from 'rxjs';
+import { AxiosResponse } from 'axios';
+
+describe('IaService', () => {
+  let service: IaService;
+  let httpService: HttpService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
+      providers: [IaService],
+    }).compile();
+
+    service = module.get<IaService>(IaService);
+    httpService = module.get<HttpService>(HttpService);
+  });
+
+  it('should request lineup to ia-service', async () => {
+    const data = { lineup: 'test' };
+    jest
+      .spyOn(httpService, 'post')
+      .mockReturnValue(of({ data } as AxiosResponse));
+
+    const result = await service.suggestLineup(['a', 'b'], '4-4-2');
+    expect(httpService.post).toHaveBeenCalledWith('/ia/suggest_lineup', {
+      players: ['a', 'b'],
+      formation: '4-4-2',
+    });
+    expect(result).toEqual(data);
+  });
+});

--- a/backend/src/modules/ia/ia.service.ts
+++ b/backend/src/modules/ia/ia.service.ts
@@ -1,4 +1,19 @@
 import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { LineupResponseDto } from './dto/lineup-response.dto';
 
 @Injectable()
-export class IaService {}
+export class IaService {
+  constructor(private readonly http: HttpService) {}
+
+  async suggestLineup(
+    players: string[],
+    formation: string,
+  ): Promise<LineupResponseDto> {
+    const response = await firstValueFrom(
+      this.http.post('/ia/suggest_lineup', { players, formation }),
+    );
+    return response.data;
+  }
+}


### PR DESCRIPTION
## Summary
- enable HttpModule and DTOs for ia module
- add integration tests for calling ia-service
- expose IA_SERVICE_URL in env example
- include nestjs/axios and supertest dependencies

## Testing
- `npm test` *(fails: jest not found)*