### PR TITLE
Add Docker image publishing

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -42,5 +42,16 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker image
-        run: docker build -t backend ./backend
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/backend:${{ github.sha }} ./backend
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/backend:${{ github.sha }} ${{ secrets.DOCKERHUB_USERNAME }}/backend:latest
+      - name: Push image
+        run: |
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/backend:${{ github.sha }}
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/backend:latest

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,3 +23,14 @@ jobs:
       - run: npx eslint .
       - run: npx prettier --check .
       - run: npm run build
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push image
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/frontend:${{ github.sha }} ./frontend
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/frontend:${{ github.sha }} ${{ secrets.DOCKERHUB_USERNAME }}/frontend:latest
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/frontend:${{ github.sha }}
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/frontend:latest

--- a/.github/workflows/ia-service.yml
+++ b/.github/workflows/ia-service.yml
@@ -29,5 +29,16 @@ jobs:
     needs: lint-test
     steps:
       - uses: actions/checkout@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker image
-        run: docker build -t ia-service ./ia-service
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/ia-service:${{ github.sha }} ./ia-service
+          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/ia-service:${{ github.sha }} ${{ secrets.DOCKERHUB_USERNAME }}/ia-service:latest
+      - name: Push image
+        run: |
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/ia-service:${{ github.sha }}
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/ia-service:latest

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Desde la raíz del proyecto:
 
 docker-compose up --build
 
+Para desplegar las imágenes ya publicadas en un registro se incluye
+`infra/docker-compose.prod.yml`.  Ajusta la variable `REGISTRY_USER` con tu
+nombre de usuario en el registro y ejecuta:
+
+```bash
+REGISTRY_USER=<usuario> docker-compose -f infra/docker-compose.prod.yml up -d
+```
+
 Servicios incluidos:
 
 - PostgreSQL
@@ -103,11 +111,16 @@ npx typeorm migration:run -d src/data-source.ts
 
 CI/CD:
 
-Los flujos de integración continua están definidos en .github/workflows/
+Los flujos de integración continua están definidos en `.github/workflows/` y
+construyen y publican las imágenes de Docker de cada servicio:
 
-- backend.yml → lint, test y build Docker del backend
-- frontend.yml → lint y build estático del frontend
-- ia-service.yml → lint y test del servicio IA
+- `backend.yml` → lint, test y push del backend
+- `frontend.yml` → lint, build estático y push del frontend
+- `ia-service.yml` → lint, test y push del servicio IA
+
+Para autenticarse en el registro, configura en el repositorio los secretos
+`DOCKERHUB_USERNAME` y `DOCKERHUB_TOKEN` con tus credenciales de Docker Hub (o
+registro compatible).
 
 ---
 

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,0 +1,94 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:14
+    container_name: infra-postgres-1
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: sandeidb
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - backend-net
+
+  mongo:
+    image: mongo:6
+    restart: always
+    env_file:
+      - ../.env
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+    volumes:
+      - mongodata:/data/db
+    networks:
+      - backend-net
+
+  redis:
+    image: redis:7
+    restart: always
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
+    networks:
+      - backend-net
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    restart: always
+    env_file:
+      - ../.env
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+    ports:
+      - "15672:15672"
+    volumes:
+      - rabbitmqdata:/var/lib/rabbitmq
+    networks:
+      - backend-net
+
+  backend:
+    image: ${REGISTRY_USER}/backend:${TAG:-latest}
+    env_file:
+      - ../backend/.env.example
+    depends_on:
+      - postgres
+    ports:
+      - "${BACKEND_PORT}:3000"
+    networks:
+      - backend-net
+
+  ia-service:
+    image: ${REGISTRY_USER}/ia-service:${TAG:-latest}
+    env_file:
+      - ../ia-service/.env.example
+    depends_on:
+      - mongo
+    ports:
+      - "${FASTAPI_PORT}:8000"
+    networks:
+      - backend-net
+
+  frontend:
+    image: ${REGISTRY_USER}/frontend:${TAG:-latest}
+    env_file:
+      - ../frontend/.env.example
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"
+    networks:
+      - backend-net
+
+networks:
+  backend-net:
+    driver: bridge
+
+volumes:
+  pgdata:
+  mongodata:
+  rabbitmqdata:
+


### PR DESCRIPTION
## Summary
- push Docker images for frontend, backend and ia-service from CI
- document registry secrets and production compose
- add `docker-compose.prod.yml` for deployment of built images

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` in frontend *(fails: missing dependencies)*
- `pytest` *(fails: command not found)*