### PR TITLE
Unify DATABASE_URL usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # PostgreSQL
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=secret_password
-POSTGRES_DB=my_database
+POSTGRES_DB=sandeidb
 
 # MongoDB
 MONGO_USER=admin

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ El archivo `infra/swagger.yaml` describe los endpoints principales como
 Asegurarse de copiar `.env.example` a `.env` en cada servicio (`backend/`,
 `frontend/` e `ia-service/`) y completar los valores necesarios.
 
+La conexión a la base de datos se configura mediante la variable
+`DATABASE_URL` incluida en dichos archivos.
+
 El frontend utiliza la variable `VITE_API_URL` para apuntar a la URL base del backend.
 Los directorios `backend/` y `frontend/` incluyen Dockerfiles para construir las imágenes de ambos servicios.
 
@@ -90,6 +93,9 @@ uvicorn main:app --reload
 ---
 
 Migraciones con TypeORM:
+
+Las migraciones utilizan la URL definida en `DATABASE_URL` para conectarse a
+la base de datos.
 
 Generar migración:
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,3 @@
 BACKEND_PORT=3000
-DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
 JWT_SECRET=supersecret

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,17 +1,10 @@
 import { DataSource } from 'typeorm';
 import { config } from 'dotenv';
-import { Player } from './modules/players/player.entity';
-// importa aquí más entidades si las tienes
-
 config(); // carga variables de .env
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
-  host: process.env.DB_HOST || 'localhost',
-  port: parseInt(process.env.DB_PORT ?? '5432', 10),
-  username: process.env.DB_USER || 'postgres',
-  password: process.env.DB_PASS || '',
-  database: process.env.DB_NAME || 'my_project',
+  url: process.env.DATABASE_URL,
   entities: [__dirname + '/**/*.entity{.ts,.js}'],
   migrations: [__dirname + '/migrations/*{.ts,.js}'],
   synchronize: false,


### PR DESCRIPTION
## Summary
- use DATABASE_URL for Nest data source
- update env example files with unified settings
- document DATABASE_URL in README

## Testing
- `npm run typeorm migration:run -d src/data-source.ts` *(fails: ts-node not found)*
- `npm run lint` *(fails: couldn't find configuration)*
- `npm test` *(fails: jest not found)*