### PR TITLE
Fix frontend version numbers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sandei-frontend-vite",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sandei-frontend-vite",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.2",
         "@tanstack/react-query": "^5.76.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandei-frontend-vite",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- update frontend `package.json` to version 1.0.0
- update `package-lock.json` accordingly

## Testing
- `npm run test` in `backend` *(fails: jest not found)*
- `npm run test` in `frontend` *(fails: vitest not found)*