### PR TITLE
Improve formations, ratings and frontend API usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Environment configuration
 .env
 infra/.env
+# Node dependencies
+node_modules/
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ El archivo `infra/swagger.yaml` describe los endpoints principales como
 
 Asegurarse de copiar `.env.example` a `.env` en cada servicio (`backend/`,
 `frontend/` e `ia-service/`) y completar los valores necesarios.
+Para levantar la infraestructura con Docker Compose también se incluye un
+archivo `.env.example` en la raíz del proyecto. Cópialo a `.env` y ajusta las
+variables según tu entorno.
 
 La conexión a la base de datos se configura mediante la variable
 `DATABASE_URL` incluida en dichos archivos.

--- a/backend/src/modules/formations/dto/update-formation.dto.ts
+++ b/backend/src/modules/formations/dto/update-formation.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateFormationDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/backend/src/modules/formations/formations.controller.ts
+++ b/backend/src/modules/formations/formations.controller.ts
@@ -13,6 +13,7 @@ import {
 import { FormationsService } from "./formations.service";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { CreateFormationDto } from "./dto/create-formation.dto";
+import { UpdateFormationDto } from "./dto/update-formation.dto";
 
 @Controller("formations")
 export class FormationsController {
@@ -35,7 +36,7 @@ export class FormationsController {
   @Put(":id")
   async update(
     @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
-    @Body() body: any,
+    @Body() body: UpdateFormationDto,
   ) {
     const formation = await this.formationsService.update(id, body);
     if (!formation) throw new NotFoundException("Formation not found");

--- a/backend/src/modules/ratings/ratings.service.spec.ts
+++ b/backend/src/modules/ratings/ratings.service.spec.ts
@@ -18,7 +18,7 @@ describe('RatingsService', () => {
         RatingsService,
         {
           provide: getRepositoryToken(Rating),
-          useValue: { create: jest.fn(), save: jest.fn() },
+          useValue: { create: jest.fn(), save: jest.fn(), findOne: jest.fn() },
         },
         {
           provide: getRepositoryToken(Match),
@@ -49,5 +49,18 @@ describe('RatingsService', () => {
     expect(ratingsRepo.create).toHaveBeenCalledWith({ score: 8, comment: 'good', match, player });
     expect(ratingsRepo.save).toHaveBeenCalled();
     expect(result).toEqual({ id: 'r1' });
+  });
+
+  it('throws if score out of range', async () => {
+    await expect(service.create('m1', 'p1', 11)).rejects.toThrow();
+  });
+
+  it('throws on duplicate rating', async () => {
+    const match = { id: 'm1' } as Match;
+    const player = { id: 'p1' } as Player;
+    (matchesRepo.findOne as jest.Mock).mockResolvedValue(match);
+    (playersRepo.findOne as jest.Mock).mockResolvedValue(player);
+    (ratingsRepo.findOne as jest.Mock).mockResolvedValue({ id: 'r1' });
+    await expect(service.create('m1', 'p1', 5)).rejects.toThrow();
   });
 });

--- a/backend/src/modules/ratings/ratings.service.ts
+++ b/backend/src/modules/ratings/ratings.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Rating } from './rating.entity';
@@ -18,6 +22,15 @@ export class RatingsService {
     if (!match) throw new NotFoundException('Match not found');
     const player = await this.playersRepo.findOne({ where: { id: playerId } });
     if (!player) throw new NotFoundException('Player not found');
+    if (score < 0 || score > 10) {
+      throw new BadRequestException('Score must be between 0 and 10');
+    }
+    const existing = await this.ratingsRepo.findOne({
+      where: { match: { id: matchId }, player: { id: playerId } },
+    });
+    if (existing) {
+      throw new BadRequestException('Rating already exists for this player and match');
+    }
     const rating = this.ratingsRepo.create({ score, comment, match, player });
     return this.ratingsRepo.save(rating);
   }

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import axios from "axios"
+import api from "../services/api"
 import { toast } from "sonner"
 
 export interface Player {
@@ -8,13 +8,8 @@ export interface Player {
   stats?: any
 }
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000"
-
 const fetchPlayers = async (): Promise<Player[]> => {
-  const token = localStorage.getItem("token")
-  const res = await axios.get(`${API_URL}/players`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
+  const res = await api.get("/players")
   return res.data
 }
 
@@ -29,10 +24,7 @@ export const useCreatePlayer = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (playerData: any) => {
-      const token = localStorage.getItem("token")
-      const res = await axios.post(`${API_URL}/players`, playerData, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      const res = await api.post("/players", playerData)
       return res.data
     },
     onSuccess: () => {
@@ -49,10 +41,7 @@ export const useUpdatePlayer = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async ({ id, data }: { id: string; data: any }) => {
-      const token = localStorage.getItem("token")
-      const res = await axios.put(`${API_URL}/players/${id}`, data, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      const res = await api.put(`/players/${id}`, data)
       return res.data
     },
     onSuccess: () => {
@@ -69,10 +58,7 @@ export const useDeletePlayer = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (id: string) => {
-      const token = localStorage.getItem("token")
-      await axios.delete(`${API_URL}/players/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      await api.delete(`/players/${id}`)
     },
     onSuccess: () => {
       toast.success("Jugador eliminado")

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,12 +1,10 @@
 import { useState } from "react"
 import { useNavigate, Link } from "react-router-dom"
-import axios from "axios"
+import api from "../services/api"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000"
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
@@ -30,7 +28,7 @@ export default function Login() {
     setLoading(true)
 
     try {
-      const res = await axios.post(`${API_URL}/auth/login`, {
+      const res = await api.post("/auth/login", {
         email,
         password,
       })

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000',
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;

--- a/frontend/src/services/formations.ts
+++ b/frontend/src/services/formations.ts
@@ -1,26 +1,11 @@
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+import api from "./api";
 
 export async function createFormation(data: { name: string; description?: string }) {
-  const token = localStorage.getItem("token");
-  const res = await fetch(`${API_URL}/formations`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  });
-
-  if (!res.ok) throw new Error("Error creating formation");
-  return res.json();
+  const res = await api.post("/formations", data);
+  return res.data;
 }
 
 export async function getFormations() {
-  const token = localStorage.getItem("token");
-  const res = await fetch(`${API_URL}/formations`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-
-  if (!res.ok) throw new Error("Error fetching formations");
-  return res.json();
+  const res = await api.get("/formations");
+  return res.data;
 }

--- a/frontend/src/services/playerService.ts
+++ b/frontend/src/services/playerService.ts
@@ -1,66 +1,19 @@
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000"
-
+import api from "./api"
 
 export async function createPlayer(data: { name: string; stats: object }) {
-  const token = localStorage.getItem("token")
-  const res = await fetch(`${API_URL}/players`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  })
-
-  if (!res.ok) {
-    throw new Error("Error al crear el jugador")
-  }
-
-  return res.json()
+  const res = await api.post("/players", data)
+  return res.data
 }
 export async function deletePlayer(id: string) {
-  const token = localStorage.getItem("token")
-  const res = await fetch(`${API_URL}/players/${id}`, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  })
-
-  if (!res.ok) {
-    throw new Error("Error al eliminar el jugador")
-  }
+  await api.delete(`/players/${id}`)
 }
 export async function updatePlayer(id: string, data: { name: string; stats: object }) {
-  const token = localStorage.getItem("token")
-  const res = await fetch(`${API_URL}/players/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  })
-
-  if (!res.ok) {
-    throw new Error("Error al actualizar el jugador")
-  }
-
-  return res.json()
+  const res = await api.put(`/players/${id}`, data)
+  return res.data
 }
 export async function getPlayers() {
-  const token = localStorage.getItem("token")
-  const res = await fetch(`${API_URL}/players`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  })
-
-  if (!res.ok) {
-    throw new Error("Error al obtener jugadores")
-  }
-
-  return res.json()
+  const res = await api.get("/players")
+  return res.data
 }
 
 


### PR DESCRIPTION
## Summary
- add UpdateFormationDto and use it in controller
- validate ratings creation (score range and duplicates)
- centralize frontend API calls with Axios instance
- document root `.env.example`
- ignore node_modules globally

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*