### PR TITLE
Add env vars docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ FASTAPI_HOST=0.0.0.0
 FASTAPI_PORT=8000
 MONGO_URL=mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/
 RABBITMQ_URL=amqp://${RABBITMQ_USER}:${RABBITMQ_PASSWORD}@rabbitmq:5672/
+
+# Deployment (docker-compose.prod.yml)
+REGISTRY_USER=myuser
+TAG=latest

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ La conexión a la base de datos se configura mediante la variable
 El frontend utiliza la variable `VITE_API_URL` para apuntar a la URL base del backend.
 Los directorios `backend/` y `frontend/` incluyen Dockerfiles para construir las imágenes de ambos servicios.
 
+### Variables de entorno
+
+El archivo `.env.example` ubicado en la raíz define las credenciales y puertos
+que utiliza Docker Compose. Copia este archivo a `.env` y ajusta los valores
+según tu entorno. Las principales variables son:
+
+- `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`: credenciales de PostgreSQL.
+- `MONGO_USER`, `MONGO_PASSWORD`: credenciales de MongoDB.
+- `REDIS_PASSWORD`: contraseña utilizada por Redis.
+- `RABBITMQ_USER`, `RABBITMQ_PASSWORD`: usuario y contraseña de RabbitMQ.
+- `BACKEND_PORT`: puerto expuesto por el servicio backend.
+- `FASTAPI_PORT`: puerto del servicio de IA.
+- `REGISTRY_USER` y `TAG`: usados por `docker-compose.prod.yml` para indicar el
+  repositorio y la etiqueta de las imágenes.
+
+Cada servicio cuenta además con su propio `.env.example` donde se incluyen
+variables específicas como `JWT_SECRET`, `IA_SERVICE_URL`, `VITE_API_URL` u
+`OPENAI_API_KEY`.
+
 ---
 
 Uso sin Docker (modo desarrollo):


### PR DESCRIPTION
## Summary
- document env vars used by the compose files
- extend `.env.example` with registry variables

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test` in frontend *(fails: vitest not found)*