### PR TITLE
Centralize backend env config

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,18 @@
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} environment variable is required`);
+  }
+  return value;
+}
+
+export const env = {
+  backendPort: parseInt(process.env.BACKEND_PORT || '3000', 10),
+  databaseUrl: requireEnv('DATABASE_URL'),
+  jwtSecret: requireEnv('JWT_SECRET'),
+  iaServiceUrl: requireEnv('IA_SERVICE_URL'),
+};

--- a/backend/src/config/typeorm.config.ts
+++ b/backend/src/config/typeorm.config.ts
@@ -1,11 +1,9 @@
-import * as dotenv from 'dotenv';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
-
-dotenv.config();
+import { env } from './env';
 
 export const typeOrmConfig: TypeOrmModuleOptions = {
   type: 'postgres',
-  url: process.env.DATABASE_URL,
+  url: env.databaseUrl,
   autoLoadEntities: true,
   synchronize: false,
   migrationsRun: true,

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -1,10 +1,9 @@
 import { DataSource } from 'typeorm';
-import { config } from 'dotenv';
-config(); // carga variables de .env
+import { env } from './config/env';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
-  url: process.env.DATABASE_URL,
+  url: env.databaseUrl,
   entities: [__dirname + '/**/*.entity{.ts,.js}'],
   migrations: [__dirname + '/migrations/*{.ts,.js}'],
   synchronize: false,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,12 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { env } from './config/env';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
-  const port = process.env.BACKEND_PORT || 3000;
-  await app.listen(port);
-  console.log(`🚀 Backend listening on port ${port}`);
+  await app.listen(env.backendPort);
+  console.log(`🚀 Backend listening on port ${env.backendPort}`);
 }
 bootstrap();

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -6,19 +6,14 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { User } from './user.entity';
 import { JwtStrategy } from './jwt.strategy';
+import { env } from '../../config/env';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([User]),
     PassportModule,
     JwtModule.register({
-      secret: (() => {
-        const jwtSecret = process.env.JWT_SECRET;
-        if (!jwtSecret) {
-          throw new Error('JWT_SECRET environment variable is required');
-        }
-        return jwtSecret;
-      })(),
+      secret: env.jwtSecret,
       signOptions: { expiresIn: '1h' },
     }),
   ],

--- a/backend/src/modules/auth/jwt.strategy.ts
+++ b/backend/src/modules/auth/jwt.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { env } from '../../config/env';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -8,7 +9,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'secret',
+      secretOrKey: env.jwtSecret,
     });
   }
 

--- a/backend/src/modules/ia/ia.module.ts
+++ b/backend/src/modules/ia/ia.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { IaService } from './ia.service';
 import { IaController } from './ia.controller';
+import { env } from '../../config/env';
 
 @Module({
   imports: [
     HttpModule.register({
-      baseURL: process.env.IA_SERVICE_URL || 'http://localhost:8000',
+      baseURL: env.iaServiceUrl,
     }),
   ],
   providers: [IaService],


### PR DESCRIPTION
## Summary
- create backend config helper for environment variables
- use the helper in TypeORM config
- use the helper in main bootstrap
- configure IA module with helper
- configure Auth module with helper
- use helper inside JWT strategy
- use helper in data source

## Testing
- `npm run lint` *(fails: ESLint plugin missing)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*