### PR TITLE
Implement global entity not found filter

### DIFF
--- a/backend/src/filters/entity-not-found.filter.ts
+++ b/backend/src/filters/entity-not-found.filter.ts
@@ -1,0 +1,14 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { EntityNotFoundError } from 'typeorm';
+
+@Catch(EntityNotFoundError)
+export class EntityNotFoundFilter implements ExceptionFilter {
+  catch(exception: EntityNotFoundError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    response.status(HttpStatus.NOT_FOUND).json({
+      statusCode: HttpStatus.NOT_FOUND,
+      message: 'Entity not found',
+    });
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,11 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { EntityNotFoundFilter } from './filters/entity-not-found.filter';
 import { env } from './config/env';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.useGlobalFilters(new EntityNotFoundFilter());
   await app.listen(env.backendPort);
   console.log(`🚀 Backend listening on port ${env.backendPort}`);
 }

--- a/backend/src/modules/matches/__tests__/matches.controller.spec.ts
+++ b/backend/src/modules/matches/__tests__/matches.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { EntityNotFoundError } from 'typeorm';
+import { Match } from '../match.entity';
 import { MatchesController } from '../matches.controller';
 import { MatchesService } from '../matches.service';
 
@@ -28,9 +29,9 @@ describe('MatchesController', () => {
     service = module.get<MatchesService>(MatchesService);
   });
 
-  it('throws NotFoundException when match not found', async () => {
-    (service.findById as jest.Mock).mockResolvedValue(null);
-    await expect(controller.findOne('x')).rejects.toBeInstanceOf(NotFoundException);
+  it('throws EntityNotFoundError when match not found', async () => {
+    (service.findById as jest.Mock).mockRejectedValue(new EntityNotFoundError(Match, 'test'));
+    await expect(controller.findOne('x')).rejects.toBeInstanceOf(EntityNotFoundError);
   });
 
   it('calls service to create a match', () => {

--- a/backend/src/modules/matches/matches.controller.ts
+++ b/backend/src/modules/matches/matches.controller.ts
@@ -7,7 +7,6 @@ import {
   Param,
   Body,
   ParseUUIDPipe,
-  NotFoundException,
   UseGuards,
 } from "@nestjs/common";
 import { MatchesService } from "./matches.service";
@@ -29,9 +28,7 @@ export class MatchesController {
   @UseGuards(JwtAuthGuard)
   @Get(":id")
   async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
-    const match = await this.matchesService.findById(id);
-    if (!match) throw new NotFoundException("Match not found");
-    return match;
+    return this.matchesService.findById(id);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -53,16 +50,13 @@ export class MatchesController {
     const data: Partial<Match> = body.date
       ? { ...body, date: new Date(body.date) }
       : body;
-    const match = await this.matchesService.update(id, data);
-    if (!match) throw new NotFoundException("Match not found");
-    return match;
+    return this.matchesService.update(id, data);
   }
 
   @UseGuards(JwtAuthGuard)
   @Delete(":id")
   async remove(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
-    const match = await this.matchesService.remove(id);
-    if (!match) throw new NotFoundException("Match not found");
+    await this.matchesService.remove(id);
     return { success: true };
   }
 }

--- a/backend/src/modules/matches/matches.service.ts
+++ b/backend/src/modules/matches/matches.service.ts
@@ -19,19 +19,17 @@ export class MatchesService {
   }
 
   findById(id: string) {
-    return this.matchesRepo.findOne({ where: { id } });
+    return this.matchesRepo.findOneByOrFail({ id });
   }
 
   async update(id: string, data: Partial<Match>) {
     await this.matchesRepo.update(id, data);
-    return this.matchesRepo.findOne({ where: { id } });
+    return this.matchesRepo.findOneByOrFail({ id });
   }
 
   async remove(id: string) {
-    const match = await this.matchesRepo.findOne({ where: { id } });
-    if (match) {
-      await this.matchesRepo.remove(match);
-    }
+    const match = await this.matchesRepo.findOneByOrFail({ id });
+    await this.matchesRepo.remove(match);
     return match;
   }
 }

--- a/backend/src/modules/players/__tests__/players.controller.spec.ts
+++ b/backend/src/modules/players/__tests__/players.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { EntityNotFoundError } from 'typeorm';
+import { Player } from '../player.entity';
 import { PlayersController } from '../players.controller';
 import { PlayersService } from '../players.service';
 
@@ -28,9 +29,9 @@ describe('PlayersController', () => {
     service = module.get<PlayersService>(PlayersService);
   });
 
-  it('throws NotFoundException when player not found', async () => {
-    (service.findOne as jest.Mock).mockResolvedValue(null);
-    await expect(controller.findOne('x')).rejects.toBeInstanceOf(NotFoundException);
+  it('throws EntityNotFoundError when player not found', async () => {
+    (service.findOne as jest.Mock).mockRejectedValue(new EntityNotFoundError(Player, 'test'));
+    await expect(controller.findOne('x')).rejects.toBeInstanceOf(EntityNotFoundError);
   });
 
   it('calls service to create a player', () => {

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -6,7 +6,6 @@ import {
   Delete,
   Body,
   Param,
-  NotFoundException,
   ParseUUIDPipe,
   UseGuards,
 } from "@nestjs/common";
@@ -28,9 +27,7 @@ export class PlayersController {
   @UseGuards(JwtAuthGuard)
   @Get(":id")
   async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
-    const player = await this.playersService.findOne(id);
-    if (!player) throw new NotFoundException("Player not found");
-    return player;
+    return this.playersService.findOne(id);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -45,16 +42,13 @@ export class PlayersController {
     @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
     @Body() body: UpdatePlayerDto,
   ) {
-    const player = await this.playersService.update(id, body);
-    if (!player) throw new NotFoundException("Player not found");
-    return player;
+    return this.playersService.update(id, body);
   }
 
   @UseGuards(JwtAuthGuard)
   @Delete(":id")
   async remove(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
-    const deleted = await this.playersService.remove(id);
-    if (!deleted) throw new NotFoundException("Player not found");
+    await this.playersService.remove(id);
     return { success: true };
   }
 }

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -19,19 +19,17 @@ export class PlayersService {
   }
 
   findOne(id: string) {
-    return this.playersRepo.findOne({ where: { id } });
+    return this.playersRepo.findOneByOrFail({ id });
   }
 
   async update(id: string, data: Partial<Player>) {
     await this.playersRepo.update(id, data);
-    return this.playersRepo.findOne({ where: { id } });
+    return this.playersRepo.findOneByOrFail({ id });
   }
 
   async remove(id: string) {
-    const player = await this.playersRepo.findOne({ where: { id } });
-    if (player) {
-      await this.playersRepo.remove(player);
-    }
+    const player = await this.playersRepo.findOneByOrFail({ id });
+    await this.playersRepo.remove(player);
     return player;
   }
 }


### PR DESCRIPTION
## Summary
- add `EntityNotFoundFilter` to translate TypeORM errors into HTTP 404
- register filter globally
- rely on repository `findOneByOrFail` in player and match services
- simplify controllers
- adjust unit tests for new behaviour

## Testing
- `npm test` *(fails: jest not found)*