### PR TITLE
Fix player migration for UUID

### DIFF
--- a/backend/src/migrations/1747088295096-CreatePlayersTable.ts
+++ b/backend/src/migrations/1747088295096-CreatePlayersTable.ts
@@ -4,7 +4,13 @@ export class CreatePlayersTable1747088295096 implements MigrationInterface {
     name = 'CreatePlayersTable1747088295096'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "players" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "position" character varying NOT NULL, "isActive" boolean NOT NULL DEFAULT true, CONSTRAINT "PK_de22b8fdeee0c33ab55ae71da3b" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "players" (
+            "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+            "name" character varying NOT NULL,
+            "position" character varying,
+            "score" integer NOT NULL DEFAULT 0,
+            CONSTRAINT "PK_players_id" PRIMARY KEY ("id")
+        )`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
## Summary
- fix players migration to use uuid primary key and include score column

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: No module named 'httpx')*
