### PR TITLE
Improve OpenAI interactions

### DIFF
--- a/ia-service/requirements.txt
+++ b/ia-service/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 openai
+httpx


### PR DESCRIPTION
## Summary
- support dependency injection of HTTP client in ia-service
- fetch OpenAI responses with retries and exponential backoff
- handle missing httpx gracefully
- adjust tests for new dependency injection
- add httpx to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*