### PR TITLE
Add jest and vitest type configs

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es2018",
     "lib": ["ES2018", "DOM"],
-    "types": [],
+    "types": ["jest"],
     "allowJs": true,
     "skipDefaultLibCheck": true,
     "strict": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,8 @@
     "vite": "^6.3.5",
     "vitest": "^1.0.0",
     "jsdom": "^23.0.0",
+    "@types/react-router-dom": "^5.3.3",
+    "@types/react-icons": "^3.0.0",
     "@testing-library/react": "^14.2.1",
     "@testing-library/jest-dom": "^6.3.1"
   }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -21,7 +21,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["vitest/globals"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add Jest types for backend compilation
- configure Vitest types in frontend tsconfig
- include missing React type packages

## Testing
- `npm run build` in `backend`
- `npm test` in `backend` *(fails: supertest types missing)*
- `npm run build` in `frontend` *(fails: missing modules)*
- `npm test` in `frontend` *(fails: vitest not found)*