### PR TITLE
Improve env handling and add tests

### DIFF
--- a/backend/src/modules/ia/ia.controller.spec.ts
+++ b/backend/src/modules/ia/ia.controller.spec.ts
@@ -5,7 +5,7 @@ import { HttpService } from '@nestjs/axios';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { of } from 'rxjs';
 import { AxiosResponse } from 'axios';
-import * as request from 'supertest';
+import request from 'supertest';
 
 describe('IaController', () => {
   let app: INestApplication;

--- a/backend/src/modules/ia/ia.service.spec.ts
+++ b/backend/src/modules/ia/ia.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { HttpModule, HttpService } from '@nestjs/axios';
 import { IaService } from './ia.service';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { AxiosResponse } from 'axios';
 
 describe('IaService', () => {
@@ -30,5 +30,14 @@ describe('IaService', () => {
       formation: '4-4-2',
     });
     expect(result).toEqual(data);
+  });
+
+  it('logs and rethrows errors from http service', async () => {
+    jest
+      .spyOn(httpService, 'post')
+      .mockReturnValue(throwError(() => new Error('fail')));
+    const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
+    await expect(service.suggestLineup(['x'], '4-4-2')).rejects.toThrow('fail');
+    expect(logSpy).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/ia/ia.service.ts
+++ b/backend/src/modules/ia/ia.service.ts
@@ -1,19 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { LineupResponseDto } from './dto/lineup-response.dto';
 
 @Injectable()
 export class IaService {
+  private readonly logger = new Logger(IaService.name);
   constructor(private readonly http: HttpService) {}
 
   async suggestLineup(
     players: string[],
     formation: string,
   ): Promise<LineupResponseDto> {
-    const response = await firstValueFrom(
-      this.http.post('/ia/suggest_lineup', { players, formation }),
-    );
-    return response.data;
+    try {
+      const response = await firstValueFrom(
+        this.http.post('/ia/suggest_lineup', { players, formation }),
+      );
+      return response.data;
+    } catch (error) {
+      this.logger.error('Failed to suggest lineup', error as Error);
+      throw error;
+    }
   }
 }

--- a/frontend/src/components/PrivateRoute.spec.tsx
+++ b/frontend/src/components/PrivateRoute.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import { MemoryRouter } from 'react-router-dom'
 import PrivateRoute from './PrivateRoute'
 import * as authService from '@/services/authService'

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -2,10 +2,16 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import api from "../services/api"
 import { toast } from "sonner"
 
+export interface PlayerStats {
+  [key: string]: number
+}
+
 export interface Player {
   id: string
   name: string
-  stats?: any
+  position?: string
+  score?: number
+  stats?: PlayerStats
 }
 
 const fetchPlayers = async (): Promise<Player[]> => {
@@ -20,10 +26,17 @@ export const usePlayers = () => {
   })
 }
 
+export interface CreatePlayerInput {
+  name: string
+  position?: string
+  score?: number
+  stats?: PlayerStats
+}
+
 export const useCreatePlayer = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async (playerData: any) => {
+    mutationFn: async (playerData: CreatePlayerInput) => {
       const res = await api.post("/players", playerData)
       return res.data
     },
@@ -40,7 +53,7 @@ export const useCreatePlayer = () => {
 export const useUpdatePlayer = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ id, data }: { id: string; data: any }) => {
+    mutationFn: async ({ id, data }: { id: string; data: Partial<CreatePlayerInput> }) => {
       const res = await api.put(`/players/${id}`, data)
       return res.data
     },

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import Login from './Login';
+
+describe('Login page', () => {
+  it('renders login form', () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Iniciar sesi\u00f3n/i)).toBeInTheDocument();
+  });
+});

--- a/ia-service/app/main.py
+++ b/ia-service/app/main.py
@@ -2,10 +2,7 @@ from fastapi import FastAPI, HTTPException, status, Depends
 from pydantic import BaseModel
 from typing import List, Optional
 import os
-try:
-    import httpx
-except Exception:  # pragma: no cover - httpx may not be installed
-    httpx = None
+import httpx
 import asyncio
 from contextlib import asynccontextmanager
 
@@ -35,8 +32,6 @@ async def fetch_chat_completion(
 
 @asynccontextmanager
 async def get_http_client():
-    if not httpx:
-        raise HTTPException(status_code=500, detail="httpx not available")
     async with httpx.AsyncClient() as client:
         yield client
 

--- a/run_local.sh
+++ b/run_local.sh
@@ -9,6 +9,7 @@ cd "$ROOT_DIR"
 if [ ! -f .env ]; then
   echo "[run_local] .env not found. Creating from .env.example"
   cp .env.example .env
+  echo "[run_local] Review the generated .env file and update values as needed"
 fi
 
 if command -v docker compose >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add typed Player hooks in frontend
- log errors from IaService
- add unit test for IaService error flow
- ensure PrivateRoute and Login page use jest-dom
- add simple Login page test
- remove optional httpx check in FastAPI service
- warn users when run_local.sh generates a new .env

## Testing
- `npm test` in `backend`
- `npm test --silent` in `frontend`
- `pytest -q` in `ia-service` *(fails: ModuleNotFoundError: No module named 'httpx')*