### PR TITLE
Improve player type safety in frontend

### DIFF
--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -1,18 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import api from "../services/api"
 import { toast } from "sonner"
-
-export interface PlayerStats {
-  [key: string]: number
-}
-
-export interface Player {
-  id: string
-  name: string
-  position?: string
-  score?: number
-  stats?: PlayerStats
-}
+import {
+  Player,
+  CreatePlayerInput,
+} from "../types/player"
 
 const fetchPlayers = async (): Promise<Player[]> => {
   const res = await api.get("/players")
@@ -26,16 +18,10 @@ export const usePlayers = () => {
   })
 }
 
-export interface CreatePlayerInput {
-  name: string
-  position?: string
-  score?: number
-  stats?: PlayerStats
-}
 
 export const useCreatePlayer = () => {
   const queryClient = useQueryClient()
-  return useMutation({
+  return useMutation<Player, Error, CreatePlayerInput>({
     mutationFn: async (playerData: CreatePlayerInput) => {
       const res = await api.post("/players", playerData)
       return res.data
@@ -52,7 +38,7 @@ export const useCreatePlayer = () => {
 
 export const useUpdatePlayer = () => {
   const queryClient = useQueryClient()
-  return useMutation({
+  return useMutation<Player, Error, { id: string; data: Partial<CreatePlayerInput> }>({
     mutationFn: async ({ id, data }: { id: string; data: Partial<CreatePlayerInput> }) => {
       const res = await api.put(`/players/${id}`, data)
       return res.data
@@ -69,7 +55,7 @@ export const useUpdatePlayer = () => {
 
 export const useDeletePlayer = () => {
   const queryClient = useQueryClient()
-  return useMutation({
+  return useMutation<void, Error, string>({
     mutationFn: async (id: string) => {
       await api.delete(`/players/${id}`)
     },

--- a/frontend/src/services/playerService.ts
+++ b/frontend/src/services/playerService.ts
@@ -1,17 +1,18 @@
 import api from "./api"
+import { CreatePlayerInput, Player } from "../types/player"
 
-export async function createPlayer(data: { name: string; stats: object }) {
+export async function createPlayer(data: CreatePlayerInput): Promise<Player> {
   const res = await api.post("/players", data)
   return res.data
 }
 export async function deletePlayer(id: string) {
   await api.delete(`/players/${id}`)
 }
-export async function updatePlayer(id: string, data: { name: string; stats: object }) {
+export async function updatePlayer(id: string, data: Partial<CreatePlayerInput>): Promise<Player> {
   const res = await api.put(`/players/${id}`, data)
   return res.data
 }
-export async function getPlayers() {
+export async function getPlayers(): Promise<Player[]> {
   const res = await api.get("/players")
   return res.data
 }

--- a/frontend/src/types/player.ts
+++ b/frontend/src/types/player.ts
@@ -1,0 +1,18 @@
+export interface PlayerStats {
+  [key: string]: number;
+}
+
+export interface Player {
+  id: string;
+  name: string;
+  position?: string;
+  score?: number;
+  stats?: PlayerStats;
+}
+
+export interface CreatePlayerInput {
+  name: string;
+  position?: string;
+  score?: number;
+  stats?: PlayerStats;
+}


### PR DESCRIPTION
## Summary
- centralize player types in `frontend/src/types/player.ts`
- use these types in `usePlayers` hook and service
- specify generics for React Query mutations

## Testing
- `npm run lint` *(fails: 6 errors)*
- `npm run test`