### PR TITLE
Fix rating migration, enforce constraints and global client

### DIFF
--- a/backend/src/migrations/1747088295098-CreateRatingsTable.ts
+++ b/backend/src/migrations/1747088295098-CreateRatingsTable.ts
@@ -4,8 +4,8 @@ export class CreateRatingsTable1747088295098 implements MigrationInterface {
     name = 'CreateRatingsTable1747088295098'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "rating" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "score" integer NOT NULL, "comment" character varying, "playerId" uuid, "matchId" uuid, CONSTRAINT "PK_rating_id" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`ALTER TABLE "rating" ADD CONSTRAINT "FK_rating_player" FOREIGN KEY ("playerId") REFERENCES "player"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`CREATE TABLE "rating" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "score" integer NOT NULL, "comment" character varying, "playerId" uuid, "matchId" uuid, CONSTRAINT "PK_rating_id" PRIMARY KEY ("id"), CONSTRAINT "UQ_rating_player_match" UNIQUE ("playerId", "matchId"))`);
+        await queryRunner.query(`ALTER TABLE "rating" ADD CONSTRAINT "FK_rating_player" FOREIGN KEY ("playerId") REFERENCES "players"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "rating" ADD CONSTRAINT "FK_rating_match" FOREIGN KEY ("matchId") REFERENCES "match"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -9,25 +9,25 @@ export class PlayersService {
     @InjectRepository(Player) private playersRepo: Repository<Player>,
   ) {}
 
-  create(data: Partial<Player>) {
+  create(data: Partial<Player>): Promise<Player> {
     const player = this.playersRepo.create(data);
     return this.playersRepo.save(player);
   }
 
-  findAll() {
+  findAll(): Promise<Player[]> {
     return this.playersRepo.find();
   }
 
-  findOne(id: string) {
+  findOne(id: string): Promise<Player> {
     return this.playersRepo.findOneByOrFail({ id });
   }
 
-  async update(id: string, data: Partial<Player>) {
+  async update(id: string, data: Partial<Player>): Promise<Player> {
     await this.playersRepo.update(id, data);
     return this.playersRepo.findOneByOrFail({ id });
   }
 
-  async remove(id: string) {
+  async remove(id: string): Promise<Player> {
     const player = await this.playersRepo.findOneByOrFail({ id });
     await this.playersRepo.remove(player);
     return player;

--- a/backend/src/modules/ratings/rating.entity.ts
+++ b/backend/src/modules/ratings/rating.entity.ts
@@ -1,8 +1,9 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Unique } from 'typeorm';
 import { Player } from '../players/player.entity';
 import { Match } from '../matches/match.entity';
 
 @Entity('rating')
+@Unique(['player', 'match'])
 export class Rating {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/backend/src/modules/ratings/ratings.service.ts
+++ b/backend/src/modules/ratings/ratings.service.ts
@@ -4,7 +4,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { Rating } from './rating.entity';
 import { Match } from '../matches/match.entity';
 import { Player } from '../players/player.entity';
@@ -15,24 +15,31 @@ export class RatingsService {
     @InjectRepository(Rating) private ratingsRepo: Repository<Rating>,
     @InjectRepository(Match) private matchesRepo: Repository<Match>,
     @InjectRepository(Player) private playersRepo: Repository<Player>,
+    private dataSource: DataSource,
   ) {}
 
-  async create(matchId: string, playerId: string, score: number, comment?: string) {
-    const match = await this.matchesRepo.findOne({ where: { id: matchId } });
-    if (!match) throw new NotFoundException('Match not found');
-    const player = await this.playersRepo.findOne({ where: { id: playerId } });
-    if (!player) throw new NotFoundException('Player not found');
-    if (score < 0 || score > 10) {
-      throw new BadRequestException('Score must be between 0 and 10');
-    }
-    const existing = await this.ratingsRepo.findOne({
-      where: { match: { id: matchId }, player: { id: playerId } },
+  async create(matchId: string, playerId: string, score: number, comment?: string): Promise<Rating> {
+    return this.dataSource.transaction(async manager => {
+      const match = await manager.findOne(Match, { where: { id: matchId } });
+      if (!match) throw new NotFoundException('Match not found');
+
+      const player = await manager.findOne(Player, { where: { id: playerId } });
+      if (!player) throw new NotFoundException('Player not found');
+
+      if (score < 0 || score > 10) {
+        throw new BadRequestException('Score must be between 0 and 10');
+      }
+
+      const existing = await manager.findOne(Rating, {
+        where: { match: { id: matchId }, player: { id: playerId } },
+      });
+      if (existing) {
+        throw new BadRequestException('Rating already exists for this player and match');
+      }
+
+      const rating = manager.create(Rating, { score, comment, match, player });
+      return manager.save(rating);
     });
-    if (existing) {
-      throw new BadRequestException('Rating already exists for this player and match');
-    }
-    const rating = this.ratingsRepo.create({ score, comment, match, player });
-    return this.ratingsRepo.save(rating);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure `rating` table references `players` and has a unique `(playerId, matchId)` constraint
- use transactions when creating ratings
- add explicit return types to `PlayersService`
- update tests for transaction logic
- reuse a single HTTP client in the IA service

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*