### PR TITLE
Add lint dependencies to backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -57,6 +57,10 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.4.0",
-    "typeorm": "^0.3.23"
+    "typeorm": "^0.3.23",
+    "eslint": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.9.0",
+    "@typescript-eslint/parser": "^7.9.0",
+    "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- add eslint, prettier and TS lint plugins to backend `package.json`

## Testing
- `cd backend && npm test --silent`
- `cd frontend && npm test --silent`
- `cd ia-service && pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
