### PR TITLE
Add player search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Autenticación:
 Gestión de jugadores:
 
 - CRUD completo de jugadores
+- Búsqueda de jugadores por nombre
 - Campos: id, name, stats (JSONB), fitness, technical
 - Validaciones con class-validator
 - Hook usePlayers() en frontend con integración a la API

--- a/backend/src/modules/players/__tests__/players.controller.spec.ts
+++ b/backend/src/modules/players/__tests__/players.controller.spec.ts
@@ -16,6 +16,7 @@ describe('PlayersController', () => {
           provide: PlayersService,
           useValue: {
             findAll: jest.fn(),
+            searchByName: jest.fn(),
             findOne: jest.fn(),
             create: jest.fn(),
             update: jest.fn(),
@@ -37,5 +38,10 @@ describe('PlayersController', () => {
   it('calls service to create a player', () => {
     controller.create({ name: 'test' } as any);
     expect(service.create).toHaveBeenCalled();
+  });
+
+  it('searches players', () => {
+    controller.search('john');
+    expect(service.searchByName).toHaveBeenCalledWith('john');
   });
 });

--- a/backend/src/modules/players/__tests__/players.service.spec.ts
+++ b/backend/src/modules/players/__tests__/players.service.spec.ts
@@ -21,11 +21,11 @@ describe('PlayersService', () => {
             findOne: jest.fn(),
             findOneByOrFail: jest.fn(),
             update: jest.fn(),
-            remove: jest.fn(),
-          },
-        },
-      ],
-    }).compile();
+        remove: jest.fn(),
+      },
+    },
+  ],
+  }).compile();
 
     service = module.get<PlayersService>(PlayersService);
     repo = module.get(getRepositoryToken(Player));
@@ -47,6 +47,14 @@ describe('PlayersService', () => {
     (repo.findOneByOrFail as jest.Mock).mockResolvedValue(player);
     await service.remove('1');
     expect(repo.remove).toHaveBeenCalledWith(player);
+  });
+
+  it('searches players by name', async () => {
+    const players = [{ id: '1', name: 'John' }] as Player[];
+    (repo.find as jest.Mock).mockResolvedValue(players);
+    const result = await service.searchByName('jo');
+    expect(repo.find).toHaveBeenCalledWith({ where: { name: expect.anything() } });
+    expect(result).toEqual(players);
   });
 
   it('throws EntityNotFoundError when removing missing player', async () => {

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   ParseUUIDPipe,
   UseGuards,
 } from "@nestjs/common";
@@ -22,6 +23,12 @@ export class PlayersController {
   @Get()
   findAll() {
     return this.playersService.findAll();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('search')
+  search(@Query('name') name: string) {
+    return this.playersService.searchByName(name);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, ILike } from 'typeorm';
 import { Player } from './player.entity';
 
 @Injectable()
@@ -20,6 +20,10 @@ export class PlayersService {
 
   findOne(id: string): Promise<Player> {
     return this.playersRepo.findOneByOrFail({ id });
+  }
+
+  searchByName(name: string): Promise<Player[]> {
+    return this.playersRepo.find({ where: { name: ILike(`%${name}%`) } });
   }
 
   async update(id: string, data: Partial<Player>): Promise<Player> {


### PR DESCRIPTION
## Summary
- implement `searchByName` in the player service
- expose `/players/search?name=` endpoint
- test the new service and controller logic
- update README with search feature description

## Testing
- `npm test --silent`