### PR TITLE
Add player position search

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Gestión de jugadores:
 
 - CRUD completo de jugadores
 - Búsqueda de jugadores por nombre
+- Búsqueda de jugadores por posición
+- Nuevo endpoint `/players/position?position=<pos>` para filtrar por posición
 - Campos: id, name, stats (JSONB), fitness, technical
 - Validaciones con class-validator
 - Hook usePlayers() en frontend con integración a la API

--- a/backend/src/modules/players/__tests__/players.controller.spec.ts
+++ b/backend/src/modules/players/__tests__/players.controller.spec.ts
@@ -17,6 +17,7 @@ describe('PlayersController', () => {
           useValue: {
             findAll: jest.fn(),
             searchByName: jest.fn(),
+            searchByPosition: jest.fn(),
             findOne: jest.fn(),
             create: jest.fn(),
             update: jest.fn(),
@@ -43,5 +44,10 @@ describe('PlayersController', () => {
   it('searches players', () => {
     controller.search('john');
     expect(service.searchByName).toHaveBeenCalledWith('john');
+  });
+
+  it('searches players by position', () => {
+    controller.searchByPosition('forward');
+    expect(service.searchByPosition).toHaveBeenCalledWith('forward');
   });
 });

--- a/backend/src/modules/players/__tests__/players.service.spec.ts
+++ b/backend/src/modules/players/__tests__/players.service.spec.ts
@@ -21,8 +21,8 @@ describe('PlayersService', () => {
             findOne: jest.fn(),
             findOneByOrFail: jest.fn(),
             update: jest.fn(),
-        remove: jest.fn(),
-      },
+            remove: jest.fn(),
+          },
     },
   ],
   }).compile();
@@ -54,6 +54,14 @@ describe('PlayersService', () => {
     (repo.find as jest.Mock).mockResolvedValue(players);
     const result = await service.searchByName('jo');
     expect(repo.find).toHaveBeenCalledWith({ where: { name: expect.anything() } });
+    expect(result).toEqual(players);
+  });
+
+  it('searches players by position', async () => {
+    const players = [{ id: '1', position: 'Forward' }] as Player[];
+    (repo.find as jest.Mock).mockResolvedValue(players);
+    const result = await service.searchByPosition('for');
+    expect(repo.find).toHaveBeenCalledWith({ where: { position: expect.anything() } });
     expect(result).toEqual(players);
   });
 

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -32,6 +32,12 @@ export class PlayersController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get('position')
+  searchByPosition(@Query('position') position: string) {
+    return this.playersService.searchByPosition(position);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get(":id")
   async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
     return this.playersService.findOne(id);

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -26,6 +26,10 @@ export class PlayersService {
     return this.playersRepo.find({ where: { name: ILike(`%${name}%`) } });
   }
 
+  searchByPosition(position: string): Promise<Player[]> {
+    return this.playersRepo.find({ where: { position: ILike(`%${position}%`) } });
+  }
+
   async update(id: string, data: Partial<Player>): Promise<Player> {
     await this.playersRepo.update(id, data);
     return this.playersRepo.findOneByOrFail({ id });


### PR DESCRIPTION
## Summary
- search players by position in backend service
- expose `/players/position` endpoint
- test search by position
- document new players API feature

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `pytest -q` in `ia-service` *(fails: ModuleNotFoundError: No module named 'httpx')*