### PR TITLE
Finish structure and functionalities

### DIFF
--- a/backend/src/modules/formations/__tests__/formations.controller.spec.ts
+++ b/backend/src/modules/formations/__tests__/formations.controller.spec.ts
@@ -37,4 +37,11 @@ describe('FormationsController', () => {
     controller.create({ name: 'test' } as any);
     expect(service.create).toHaveBeenCalled();
   });
+
+  it('returns formation by id', async () => {
+    (service.findById as jest.Mock).mockResolvedValue({ id: '1' });
+    const result = await controller.findOne('1');
+    expect(service.findById).toHaveBeenCalledWith('1');
+    expect(result).toEqual({ id: '1' });
+  });
 });

--- a/backend/src/modules/formations/formations.controller.ts
+++ b/backend/src/modules/formations/formations.controller.ts
@@ -26,6 +26,14 @@ export class FormationsController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get(":id")
+  async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
+    const formation = await this.formationsService.findById(id);
+    if (!formation) throw new NotFoundException("Formation not found");
+    return formation;
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Post()
   // Create a new tactical formation
   create(@Body() body: CreateFormationDto) {


### PR DESCRIPTION
## Summary
- allow querying a formation by id
- test retrieving a formation by id

## Testing
- `cd backend && npm test`
- `cd frontend && npx vitest run --reporter=basic`