### PR TITLE
Integrate AI tactics predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Servicio de IA:
 - Servicio REST en FastAPI preparado para integrar funcionalidades de análisis inteligente
 - Módulo IA en el backend para futuras integraciones
 - Endpoint `/ia/analyze_performance` para evaluar el rendimiento según las calificaciones
+- Endpoint `/ia/suggest_tactics` para obtener recomendaciones tácticas mediante IA
 
 ---
 
@@ -83,7 +84,7 @@ Servicios incluidos:
 - Servicio IA (FastAPI)
 
 El archivo `infra/swagger.yaml` describe los endpoints principales como
-`/ia/suggest_lineup` y el registro de calificaciones.
+`/ia/suggest_lineup`, `/ia/suggest_tactics` y el registro de calificaciones.
 
 Asegurarse de copiar `.env.example` a `.env` en cada servicio (`backend/`,
 `frontend/` e `ia-service/`) y completar los valores necesarios.

--- a/backend/src/modules/ia/dto/tactics-request.dto.ts
+++ b/backend/src/modules/ia/dto/tactics-request.dto.ts
@@ -1,0 +1,12 @@
+import { IsArray, ArrayNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class TacticsRequestDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  players!: string[];
+
+  @IsOptional()
+  @IsString()
+  style?: string;
+}

--- a/backend/src/modules/ia/dto/tactics-response.dto.ts
+++ b/backend/src/modules/ia/dto/tactics-response.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class TacticsResponseDto {
+  @IsString()
+  tactics!: string;
+}

--- a/backend/src/modules/ia/ia.controller.spec.ts
+++ b/backend/src/modules/ia/ia.controller.spec.ts
@@ -1,3 +1,6 @@
+process.env.DATABASE_URL = 'postgres://dummy';
+process.env.JWT_SECRET = 'dummysecret';
+process.env.IA_SERVICE_URL = 'http://dummy';
 import { Test } from '@nestjs/testing';
 import { INestApplication, HttpStatus } from '@nestjs/common';
 import { IaModule } from './ia.module';
@@ -39,6 +42,18 @@ describe('IaController', () => {
     return request(app.getHttpServer())
       .post('/ia/suggest_lineup')
       .send({ players: ['x'], formation: '4-4-2' })
+      .expect(HttpStatus.CREATED)
+      .expect(data);
+  });
+
+  it('POST /ia/suggest_tactics', () => {
+    const data = { tactics: 'ok' };
+    (httpService.post as jest.Mock).mockReturnValue(
+      of({ data } as AxiosResponse),
+    );
+    return request(app.getHttpServer())
+      .post('/ia/suggest_tactics')
+      .send({ players: ['x'] })
       .expect(HttpStatus.CREATED)
       .expect(data);
   });

--- a/backend/src/modules/ia/ia.controller.ts
+++ b/backend/src/modules/ia/ia.controller.ts
@@ -3,6 +3,8 @@ import { IaService } from './ia.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { LineupRequestDto } from './dto/lineup-request.dto';
 import { LineupResponseDto } from './dto/lineup-response.dto';
+import { TacticsRequestDto } from './dto/tactics-request.dto';
+import { TacticsResponseDto } from './dto/tactics-response.dto';
 
 @Controller('ia')
 export class IaController {
@@ -12,5 +14,11 @@ export class IaController {
   @Post('suggest_lineup')
   suggestLineup(@Body() body: LineupRequestDto): Promise<LineupResponseDto> {
     return this.iaService.suggestLineup(body.players, body.formation);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('suggest_tactics')
+  suggestTactics(@Body() body: TacticsRequestDto): Promise<TacticsResponseDto> {
+    return this.iaService.suggestTactics(body.players, body.style);
   }
 }

--- a/backend/src/modules/ia/ia.service.spec.ts
+++ b/backend/src/modules/ia/ia.service.spec.ts
@@ -32,12 +32,35 @@ describe('IaService', () => {
     expect(result).toEqual(data);
   });
 
+  it('should request tactics to ia-service', async () => {
+    const data = { tactics: 'ok' };
+    jest
+      .spyOn(httpService, 'post')
+      .mockReturnValue(of({ data } as AxiosResponse));
+
+    const result = await service.suggestTactics(['a'], undefined);
+    expect(httpService.post).toHaveBeenCalledWith('/ia/suggest_tactics', {
+      players: ['a'],
+      style: undefined,
+    });
+    expect(result).toEqual(data);
+  });
+
   it('logs and rethrows errors from http service', async () => {
     jest
       .spyOn(httpService, 'post')
       .mockReturnValue(throwError(() => new Error('fail')));
     const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
     await expect(service.suggestLineup(['x'], '4-4-2')).rejects.toThrow('fail');
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('logs and rethrows errors when suggesting tactics', async () => {
+    jest
+      .spyOn(httpService, 'post')
+      .mockReturnValue(throwError(() => new Error('fail')));
+    const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
+    await expect(service.suggestTactics(['p'])).rejects.toThrow('fail');
     expect(logSpy).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/ia/ia.service.ts
+++ b/backend/src/modules/ia/ia.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { LineupResponseDto } from './dto/lineup-response.dto';
+import { TacticsResponseDto } from './dto/tactics-response.dto';
 
 @Injectable()
 export class IaService {
@@ -19,6 +20,21 @@ export class IaService {
       return response.data;
     } catch (error) {
       this.logger.error('Failed to suggest lineup', error as Error);
+      throw error;
+    }
+  }
+
+  async suggestTactics(
+    players: string[],
+    style?: string,
+  ): Promise<TacticsResponseDto> {
+    try {
+      const response = await firstValueFrom(
+        this.http.post('/ia/suggest_tactics', { players, style }),
+      );
+      return response.data;
+    } catch (error) {
+      this.logger.error('Failed to suggest tactics', error as Error);
       throw error;
     }
   }

--- a/ia-service/tests/test_suggest_tactics.py
+++ b/ia-service/tests/test_suggest_tactics.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import types
+import asyncio
+
+# Ensure the app package can be imported
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Create a minimal httpx stub
+class DummyAsyncClient:
+    async def post(self, *args, **kwargs):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+        return Resp()
+
+sys.modules['httpx'] = types.SimpleNamespace(AsyncClient=DummyAsyncClient)
+
+from app.main import suggest_tactics, TacticsRequest
+
+
+def test_suggest_tactics(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', 'test-key')
+    payload = TacticsRequest(players=["John"], style=None)
+    result = asyncio.run(suggest_tactics(payload, DummyAsyncClient()))
+    assert result == {"tactics": "ok"}

--- a/infra/swagger.yaml
+++ b/infra/swagger.yaml
@@ -19,6 +19,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LineupResponse'
+  /ia/suggest_tactics:
+    post:
+      summary: Suggest match tactics
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TacticsRequest'
+      responses:
+        '200':
+          description: Suggested tactics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TacticsResponse'
   /matches/{matchId}/ratings:
     post:
       summary: Register a player rating
@@ -55,6 +71,22 @@ components:
       type: object
       properties:
         lineup:
+          type: string
+    TacticsRequest:
+      type: object
+      properties:
+        players:
+          type: array
+          items:
+            type: string
+        style:
+          type: string
+      required:
+        - players
+    TacticsResponse:
+      type: object
+      properties:
+        tactics:
           type: string
     RatingRequest:
       type: object


### PR DESCRIPTION
## Summary
- add `/ia/suggest_tactics` endpoint to FastAPI service
- support tactics suggestion from NestJS backend
- document new endpoint in Swagger and README
- provide DTOs and tests

## Testing
- `npm test --silent`
- `pytest -q`