### PR TITLE
Add match prediction endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Servicio de IA:
 - Módulo IA en el backend para futuras integraciones
 - Endpoint `/ia/analyze_performance` para evaluar el rendimiento según las calificaciones
 - Endpoint `/ia/suggest_tactics` para obtener recomendaciones tácticas mediante IA
+- Endpoint `/ia/predict_match` para predecir el resultado de un partido
 
 ---
 
@@ -84,7 +85,7 @@ Servicios incluidos:
 - Servicio IA (FastAPI)
 
 El archivo `infra/swagger.yaml` describe los endpoints principales como
-`/ia/suggest_lineup`, `/ia/suggest_tactics` y el registro de calificaciones.
+`/ia/suggest_lineup`, `/ia/suggest_tactics`, `/ia/predict_match` y el registro de calificaciones.
 
 Asegurarse de copiar `.env.example` a `.env` en cada servicio (`backend/`,
 `frontend/` e `ia-service/`) y completar los valores necesarios.

--- a/backend/src/modules/ia/dto/match-prediction-request.dto.ts
+++ b/backend/src/modules/ia/dto/match-prediction-request.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, ArrayNotEmpty, IsString } from 'class-validator';
+
+export class MatchPredictionRequestDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  homeTeam!: string[];
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  awayTeam!: string[];
+}

--- a/backend/src/modules/ia/dto/match-prediction-response.dto.ts
+++ b/backend/src/modules/ia/dto/match-prediction-response.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class MatchPredictionResponseDto {
+  @IsString()
+  prediction!: string;
+}

--- a/backend/src/modules/ia/ia.controller.spec.ts
+++ b/backend/src/modules/ia/ia.controller.spec.ts
@@ -57,4 +57,16 @@ describe('IaController', () => {
       .expect(HttpStatus.CREATED)
       .expect(data);
   });
+
+  it('POST /ia/predict_match', () => {
+    const data = { prediction: 'x' };
+    (httpService.post as jest.Mock).mockReturnValue(
+      of({ data } as AxiosResponse),
+    );
+    return request(app.getHttpServer())
+      .post('/ia/predict_match')
+      .send({ homeTeam: ['h'], awayTeam: ['a'] })
+      .expect(HttpStatus.CREATED)
+      .expect(data);
+  });
 });

--- a/backend/src/modules/ia/ia.controller.ts
+++ b/backend/src/modules/ia/ia.controller.ts
@@ -5,6 +5,8 @@ import { LineupRequestDto } from './dto/lineup-request.dto';
 import { LineupResponseDto } from './dto/lineup-response.dto';
 import { TacticsRequestDto } from './dto/tactics-request.dto';
 import { TacticsResponseDto } from './dto/tactics-response.dto';
+import { MatchPredictionRequestDto } from './dto/match-prediction-request.dto';
+import { MatchPredictionResponseDto } from './dto/match-prediction-response.dto';
 
 @Controller('ia')
 export class IaController {
@@ -20,5 +22,13 @@ export class IaController {
   @Post('suggest_tactics')
   suggestTactics(@Body() body: TacticsRequestDto): Promise<TacticsResponseDto> {
     return this.iaService.suggestTactics(body.players, body.style);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('predict_match')
+  predictMatch(
+    @Body() body: MatchPredictionRequestDto,
+  ): Promise<MatchPredictionResponseDto> {
+    return this.iaService.predictMatch(body.homeTeam, body.awayTeam);
   }
 }

--- a/backend/src/modules/ia/ia.service.spec.ts
+++ b/backend/src/modules/ia/ia.service.spec.ts
@@ -46,6 +46,20 @@ describe('IaService', () => {
     expect(result).toEqual(data);
   });
 
+  it('should request match prediction to ia-service', async () => {
+    const data = { prediction: '2-1' };
+    jest
+      .spyOn(httpService, 'post')
+      .mockReturnValue(of({ data } as AxiosResponse));
+
+    const result = await service.predictMatch(['h'], ['a']);
+    expect(httpService.post).toHaveBeenCalledWith('/ia/predict_match', {
+      home_team: ['h'],
+      away_team: ['a'],
+    });
+    expect(result).toEqual(data);
+  });
+
   it('logs and rethrows errors from http service', async () => {
     jest
       .spyOn(httpService, 'post')

--- a/backend/src/modules/ia/ia.service.ts
+++ b/backend/src/modules/ia/ia.service.ts
@@ -38,4 +38,22 @@ export class IaService {
       throw error;
     }
   }
+
+  async predictMatch(
+    homeTeam: string[],
+    awayTeam: string[],
+  ): Promise<{ prediction: string }> {
+    try {
+      const response = await firstValueFrom(
+        this.http.post('/ia/predict_match', {
+          home_team: homeTeam,
+          away_team: awayTeam,
+        }),
+      );
+      return response.data;
+    } catch (error) {
+      this.logger.error('Failed to predict match', error as Error);
+      throw error;
+    }
+  }
 }

--- a/ia-service/app/main.py
+++ b/ia-service/app/main.py
@@ -138,3 +138,33 @@ async def analyze_performance(
         return {"analysis": analysis}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+class MatchPredictionRequest(BaseModel):
+    home_team: List[str]
+    away_team: List[str]
+
+
+@app.post("/ia/predict_match")
+async def predict_match(
+    payload: MatchPredictionRequest, client: httpx.AsyncClient = Depends(get_http_client)
+):
+    if not OPENAI_API_KEY:
+        raise HTTPException(status_code=500, detail="OpenAI not available")
+
+    prompt = (
+        "Predict the result of a football match between the home team: "
+        + ", ".join(payload.home_team)
+        + " and the away team: "
+        + ", ".join(payload.away_team)
+    )
+
+    messages = [
+        {"role": "system", "content": "You are a football match predictor."},
+        {"role": "user", "content": prompt},
+    ]
+    try:
+        prediction = await fetch_chat_completion(messages, client)
+        return {"prediction": prediction}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/ia-service/tests/test_predict_match.py
+++ b/ia-service/tests/test_predict_match.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+import asyncio
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+class DummyAsyncClient:
+    async def post(self, *args, **kwargs):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+        return Resp()
+
+sys.modules['httpx'] = types.SimpleNamespace(AsyncClient=DummyAsyncClient)
+
+from app.main import predict_match, MatchPredictionRequest
+
+
+def test_predict_match(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', 'test-key')
+    payload = MatchPredictionRequest(home_team=['A'], away_team=['B'])
+    result = asyncio.run(predict_match(payload, DummyAsyncClient()))
+    assert result == {"prediction": "ok"}

--- a/infra/swagger.yaml
+++ b/infra/swagger.yaml
@@ -35,6 +35,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TacticsResponse'
+  /ia/predict_match:
+    post:
+      summary: Predict match result
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MatchPredictionRequest'
+      responses:
+        '200':
+          description: Match prediction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MatchPredictionResponse'
   /matches/{matchId}/ratings:
     post:
       summary: Register a player rating
@@ -100,3 +116,22 @@ components:
       required:
         - playerId
         - score
+    MatchPredictionRequest:
+      type: object
+      properties:
+        homeTeam:
+          type: array
+          items:
+            type: string
+        awayTeam:
+          type: array
+          items:
+            type: string
+      required:
+        - homeTeam
+        - awayTeam
+    MatchPredictionResponse:
+      type: object
+      properties:
+        prediction:
+          type: string


### PR DESCRIPTION
## Summary
- extend IA FastAPI service with `/ia/predict_match`
- support match prediction from NestJS backend
- document endpoint in README and swagger
- test new backend and IA service features

## Testing
- `npm --prefix backend test --silent`
- `pytest ia-service/tests`