### PR TITLE
Add lineup error detection endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Servicio de IA:
 - Endpoint `/ia/analyze_performance` para evaluar el rendimiento según las calificaciones
 - Endpoint `/ia/suggest_tactics` para obtener recomendaciones tácticas mediante IA
 - Endpoint `/ia/predict_match` para predecir el resultado de un partido
+- Endpoint `/ia/detect_errors` para identificar problemas en la alineación enviada
 
 ---
 
@@ -85,7 +86,7 @@ Servicios incluidos:
 - Servicio IA (FastAPI)
 
 El archivo `infra/swagger.yaml` describe los endpoints principales como
-`/ia/suggest_lineup`, `/ia/suggest_tactics`, `/ia/predict_match` y el registro de calificaciones.
+`/ia/suggest_lineup`, `/ia/suggest_tactics`, `/ia/predict_match`, `/ia/detect_errors` y el registro de calificaciones.
 
 Asegurarse de copiar `.env.example` a `.env` en cada servicio (`backend/`,
 `frontend/` e `ia-service/`) y completar los valores necesarios.

--- a/backend/src/modules/ia/dto/error-detection-request.dto.ts
+++ b/backend/src/modules/ia/dto/error-detection-request.dto.ts
@@ -1,0 +1,12 @@
+import { IsArray, ArrayNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class ErrorDetectionRequestDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  lineup!: string[];
+
+  @IsOptional()
+  @IsString()
+  formation?: string;
+}

--- a/backend/src/modules/ia/dto/error-detection-response.dto.ts
+++ b/backend/src/modules/ia/dto/error-detection-response.dto.ts
@@ -1,0 +1,3 @@
+export class ErrorDetectionResponseDto {
+  report!: string;
+}

--- a/backend/src/modules/ia/ia.controller.spec.ts
+++ b/backend/src/modules/ia/ia.controller.spec.ts
@@ -69,4 +69,16 @@ describe('IaController', () => {
       .expect(HttpStatus.CREATED)
       .expect(data);
   });
+
+  it('POST /ia/detect_errors', () => {
+    const data = { report: 'ok' };
+    (httpService.post as jest.Mock).mockReturnValue(
+      of({ data } as AxiosResponse),
+    );
+    return request(app.getHttpServer())
+      .post('/ia/detect_errors')
+      .send({ lineup: ['a', 'b'] })
+      .expect(HttpStatus.CREATED)
+      .expect(data);
+  });
 });

--- a/backend/src/modules/ia/ia.controller.ts
+++ b/backend/src/modules/ia/ia.controller.ts
@@ -7,6 +7,8 @@ import { TacticsRequestDto } from './dto/tactics-request.dto';
 import { TacticsResponseDto } from './dto/tactics-response.dto';
 import { MatchPredictionRequestDto } from './dto/match-prediction-request.dto';
 import { MatchPredictionResponseDto } from './dto/match-prediction-response.dto';
+import { ErrorDetectionRequestDto } from './dto/error-detection-request.dto';
+import { ErrorDetectionResponseDto } from './dto/error-detection-response.dto';
 
 @Controller('ia')
 export class IaController {
@@ -30,5 +32,13 @@ export class IaController {
     @Body() body: MatchPredictionRequestDto,
   ): Promise<MatchPredictionResponseDto> {
     return this.iaService.predictMatch(body.homeTeam, body.awayTeam);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('detect_errors')
+  detectErrors(
+    @Body() body: ErrorDetectionRequestDto,
+  ): Promise<ErrorDetectionResponseDto> {
+    return this.iaService.detectErrors(body.lineup, body.formation);
   }
 }

--- a/backend/src/modules/ia/ia.service.spec.ts
+++ b/backend/src/modules/ia/ia.service.spec.ts
@@ -60,6 +60,20 @@ describe('IaService', () => {
     expect(result).toEqual(data);
   });
 
+  it('should request error detection to ia-service', async () => {
+    const data = { report: 'ok' };
+    jest
+      .spyOn(httpService, 'post')
+      .mockReturnValue(of({ data } as AxiosResponse));
+
+    const result = await service.detectErrors(['a', 'b'], undefined);
+    expect(httpService.post).toHaveBeenCalledWith('/ia/detect_errors', {
+      lineup: ['a', 'b'],
+      formation: undefined,
+    });
+    expect(result).toEqual(data);
+  });
+
   it('logs and rethrows errors from http service', async () => {
     jest
       .spyOn(httpService, 'post')
@@ -75,6 +89,15 @@ describe('IaService', () => {
       .mockReturnValue(throwError(() => new Error('fail')));
     const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
     await expect(service.suggestTactics(['p'])).rejects.toThrow('fail');
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('logs and rethrows errors when detecting lineup issues', async () => {
+    jest
+      .spyOn(httpService, 'post')
+      .mockReturnValue(throwError(() => new Error('fail')));
+    const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
+    await expect(service.detectErrors(['a'])).rejects.toThrow('fail');
     expect(logSpy).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/ia/ia.service.ts
+++ b/backend/src/modules/ia/ia.service.ts
@@ -3,6 +3,7 @@ import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { LineupResponseDto } from './dto/lineup-response.dto';
 import { TacticsResponseDto } from './dto/tactics-response.dto';
+import { ErrorDetectionResponseDto } from './dto/error-detection-response.dto';
 
 @Injectable()
 export class IaService {
@@ -53,6 +54,21 @@ export class IaService {
       return response.data;
     } catch (error) {
       this.logger.error('Failed to predict match', error as Error);
+      throw error;
+    }
+  }
+
+  async detectErrors(
+    lineup: string[],
+    formation?: string,
+  ): Promise<ErrorDetectionResponseDto> {
+    try {
+      const response = await firstValueFrom(
+        this.http.post('/ia/detect_errors', { lineup, formation }),
+      );
+      return response.data;
+    } catch (error) {
+      this.logger.error('Failed to detect errors', error as Error);
       throw error;
     }
   }

--- a/ia-service/tests/test_detect_errors.py
+++ b/ia-service/tests/test_detect_errors.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import types
+import asyncio
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+class DummyAsyncClient:
+    async def post(self, *args, **kwargs):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+        return Resp()
+
+sys.modules['httpx'] = types.SimpleNamespace(AsyncClient=DummyAsyncClient)
+
+from app.main import detect_errors, ErrorDetectionRequest
+
+
+def test_detect_errors(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', 'test-key')
+    payload = ErrorDetectionRequest(lineup=["A", "B"], formation=None)
+    result = asyncio.run(detect_errors(payload, DummyAsyncClient()))
+    assert result == {"report": "ok"}


### PR DESCRIPTION
## Summary
- expand AI service with `/ia/detect_errors`
- wire new route through NestJS controller and service
- generate DTOs for error detection
- test coverage for new API
- document the new endpoint

## Testing
- `pytest -q ia-service/tests/test_detect_errors.py`
- `npm test --silent`