### PR TITLE
Add tab bar and workflow wizards

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Dashboard from "@/pages/Dashboard"
 import Register from "@/pages/Register"
 import PrivateRoute from "@/components/PrivateRoute"
 import Players from "@/pages/Players"
+import Tactics from "@/pages/Tactics"
+import Profile from "@/pages/Profile"
 import { Toaster } from "sonner"
 import { Navigate } from "react-router-dom"
 import BottomNav from "@/components/BottomNav"
@@ -24,14 +26,30 @@ function App() {
               </PrivateRoute>
             }
           />
-          <Route
-            path="/players"
-            element={
-              <PrivateRoute>
-                <Players />
-              </PrivateRoute>
-            }
-          />
+        <Route
+          path="/players"
+          element={
+            <PrivateRoute>
+              <Players />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/tactics"
+          element={
+            <PrivateRoute>
+              <Tactics />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            <PrivateRoute>
+              <Profile />
+            </PrivateRoute>
+          }
+        />
           <Route path="*" element={<Navigate to="/login" />} />
         </Routes>
         {isAuthenticated() && <BottomNav />}

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom'
-import { FaHome, FaFutbol, FaUserFriends, FaUser } from 'react-icons/fa'
+import { FaHome, FaUserFriends, FaUser, FaChessBoard } from 'react-icons/fa'
 
 export default function BottomNav() {
   return (
@@ -8,13 +8,13 @@ export default function BottomNav() {
         <FaHome className="mb-1" />
         Inicio
       </NavLink>
-      <NavLink to="/matches" className="flex flex-col items-center">
-        <FaFutbol className="mb-1" />
-        Partidos
-      </NavLink>
       <NavLink to="/players" className="flex flex-col items-center">
         <FaUserFriends className="mb-1" />
         Jugadores
+      </NavLink>
+      <NavLink to="/tactics" className="flex flex-col items-center">
+        <FaChessBoard className="mb-1" />
+        T\u00e1cticas
       </NavLink>
       <NavLink to="/profile" className="flex flex-col items-center">
         <FaUser className="mb-1" />

--- a/frontend/src/components/FormationWizard.tsx
+++ b/frontend/src/components/FormationWizard.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import Spinner from "@/components/ui/spinner";
+
+export interface FormationWizardData {
+  name: string;
+  description: string;
+}
+
+export default function FormationWizard({
+  onComplete,
+  onCancel,
+}: {
+  onComplete: (data: FormationWizardData) => Promise<void> | void;
+  onCancel: () => void;
+}) {
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+  const totalSteps = 3;
+
+  const next = () => {
+    if (step === 1 && !name) return;
+    setStep((s) => Math.min(s + 1, totalSteps));
+  };
+
+  const prev = () => setStep((s) => Math.max(s - 1, 1));
+
+  const finish = async () => {
+    setSaving(true);
+    await onComplete({ name, description });
+    setSaving(false);
+  };
+
+  const progress = ((step - 1) / (totalSteps - 1)) * 100;
+
+  return (
+    <div className="bg-white p-6 rounded w-96">
+      <div className="h-2 bg-gray-200 rounded mb-4">
+        <div className="h-full bg-blue-600 rounded" style={{ width: `${progress}%` }} />
+      </div>
+      {step === 1 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-bold">Nombre de la formaci\u00f3n</h2>
+          <input
+            type="text"
+            className="border p-2 w-full rounded"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Nombre"
+          />
+        </div>
+      )}
+      {step === 2 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-bold">Descripci\u00f3n</h2>
+          <textarea
+            className="border p-2 w-full rounded"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Descripci\u00f3n"
+          />
+        </div>
+      )}
+      {step === 3 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-bold">Confirmar datos</h2>
+          <p>
+            <strong>Nombre:</strong> {name}
+          </p>
+          <p>
+            <strong>Descripci\u00f3n:</strong> {description}
+          </p>
+        </div>
+      )}
+      <div className="flex justify-between mt-4">
+        {step > 1 ? (
+          <button onClick={prev} className="text-blue-600 underline">
+            Atr\u00e1s
+          </button>
+        ) : (
+          <span />
+        )}
+        {step < totalSteps && (
+          <button onClick={next} className="bg-blue-600 text-white px-4 py-2 rounded">
+            Siguiente
+          </button>
+        )}
+        {step === totalSteps && (
+          <button
+            onClick={finish}
+            disabled={saving}
+            className="bg-green-600 text-white px-4 py-2 rounded flex items-center"
+          >
+            {saving && <Spinner className="h-4 w-4 mr-2 text-white" />}
+            Guardar
+          </button>
+        )}
+        <button onClick={onCancel} className="ml-2 text-red-600 underline">
+          Cancelar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PlayerWizard.tsx
+++ b/frontend/src/components/PlayerWizard.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import Spinner from "@/components/ui/spinner";
+
+export interface PlayerWizardData {
+  name: string;
+  stats: Record<string, unknown>;
+}
+
+export default function PlayerWizard({
+  initialName = "",
+  initialStats = "",
+  onComplete,
+  onCancel,
+}: {
+  initialName?: string;
+  initialStats?: string;
+  onComplete: (data: PlayerWizardData) => Promise<void> | void;
+  onCancel: () => void;
+}) {
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState(initialName);
+  const [stats, setStats] = useState(initialStats);
+  const [statsError, setStatsError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const totalSteps = 3;
+
+  const next = () => {
+    if (step === 1 && !name) return;
+    if (step === 2) {
+      try {
+        JSON.parse(stats || "{}");
+        setStatsError("");
+      } catch {
+        setStatsError("JSON inválido");
+        return;
+      }
+    }
+    setStep((s) => Math.min(s + 1, totalSteps));
+  };
+
+  const prev = () => setStep((s) => Math.max(s - 1, 1));
+
+  const finish = async () => {
+    try {
+      setSaving(true);
+      const parsed = stats ? JSON.parse(stats) : {};
+      await onComplete({ name, stats: parsed });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const progress = ((step - 1) / (totalSteps - 1)) * 100;
+
+  return (
+    <div className="bg-white p-6 rounded w-96">
+      <div className="h-2 bg-gray-200 rounded mb-4">
+        <div
+          className="h-full bg-blue-600 rounded"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      {step === 1 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-bold">Nombre del jugador</h2>
+          <input
+            type="text"
+            className="border p-2 w-full rounded"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Nombre"
+          />
+        </div>
+      )}
+      {step === 2 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-bold">Estadísticas</h2>
+          <textarea
+            className="border p-2 w-full rounded"
+            placeholder='Stats (ej: {"goals": 3})'
+            value={stats}
+            onChange={(e) => {
+              setStats(e.target.value);
+              try {
+                JSON.parse(e.target.value);
+                setStatsError("");
+              } catch {
+                setStatsError("JSON inválido");
+              }
+            }}
+          />
+          {statsError && <p className="text-red-500 text-sm">{statsError}</p>}
+        </div>
+      )}
+      {step === 3 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-bold">Confirmar datos</h2>
+          <p className="break-all">
+            <strong>Nombre:</strong> {name}
+          </p>
+          <pre className="bg-gray-100 p-2 rounded overflow-auto text-sm">
+            {stats || "{}"}
+          </pre>
+        </div>
+      )}
+      <div className="flex justify-between mt-4">
+        {step > 1 ? (
+          <button onClick={prev} className="text-blue-600 underline">
+            Atrás
+          </button>
+        ) : (
+          <span />
+        )}
+        {step < totalSteps && (
+          <button
+            onClick={next}
+            className="bg-blue-600 text-white px-4 py-2 rounded"
+          >
+            Siguiente
+          </button>
+        )}
+        {step === totalSteps && (
+          <button
+            onClick={finish}
+            disabled={saving}
+            className="bg-green-600 text-white px-4 py-2 rounded flex items-center"
+          >
+            {saving && <Spinner className="h-4 w-4 mr-2 text-white" />}
+            Guardar
+          </button>
+        )}
+        <button onClick={onCancel} className="ml-2 text-red-600 underline">
+          Cancelar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useFormations.ts
+++ b/frontend/src/hooks/useFormations.ts
@@ -1,0 +1,33 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import api from "../services/api";
+import { Formation, CreateFormationInput } from "../types/formation";
+import { toast } from "sonner";
+
+const fetchFormations = async (): Promise<Formation[]> => {
+  const res = await api.get("/formations");
+  return res.data;
+};
+
+export const useFormations = () => {
+  return useQuery<Formation[]>({
+    queryKey: ["formations"],
+    queryFn: fetchFormations,
+  });
+};
+
+export const useCreateFormation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Formation, Error, CreateFormationInput>({
+    mutationFn: async (data: CreateFormationInput) => {
+      const res = await api.post("/formations", data);
+      return res.data;
+    },
+    onSuccess: () => {
+      toast.success("Formaci\u00f3n creada");
+      queryClient.invalidateQueries({ queryKey: ["formations"] });
+    },
+    onError: () => {
+      toast.error("Error al crear formaci\u00f3n");
+    },
+  });
+};

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,0 +1,8 @@
+export default function Profile() {
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-bold">Perfil</h2>
+      <p>A\u00fan no hay contenido.</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Tactics.tsx
+++ b/frontend/src/pages/Tactics.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import {
+  useFormations,
+  useCreateFormation,
+} from "@/hooks/useFormations";
+import Spinner from "@/components/ui/spinner";
+import FormationWizard from "@/components/FormationWizard";
+
+export default function Tactics() {
+  const { data: formations, isLoading, error } = useFormations();
+  const createFormation = useCreateFormation();
+  const [showWizard, setShowWizard] = useState(false);
+
+  if (isLoading)
+    return (
+      <div className="flex justify-center mt-10">
+        <Spinner className="h-8 w-8 text-primary" />
+      </div>
+    );
+  if (error) return <p className="text-red-500 text-center mt-10">{error}</p>;
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-bold mb-4">Formaciones</h2>
+      <button
+        onClick={() => setShowWizard(true)}
+        className="bg-green-600 text-white px-4 py-2 rounded mb-4"
+      >
+        Crear formaci\u00f3n
+      </button>
+      <ul>
+        {formations.map((f) => (
+          <li key={f.id} className="border-b py-2">
+            {f.name}
+          </li>
+        ))}
+      </ul>
+      {showWizard && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <FormationWizard
+            onComplete={async (data) => {
+              await createFormation.mutateAsync(data);
+              setShowWizard(false);
+            }}
+            onCancel={() => setShowWizard(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/formation.ts
+++ b/frontend/src/types/formation.ts
@@ -1,0 +1,10 @@
+export interface Formation {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface CreateFormationInput {
+  name: string;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- implement bottom navigation with icons and tactics section
- add pages for tactics and profile
- add formation and player wizards with progress bars
- wire up new routes and hooks

## Testing
- `npm run test` in `backend`
- `npm run test -t ''` in `frontend`
