### PR TITLE
Improve UI layout with card components

### DIFF
--- a/frontend/src/components/FormationCard.tsx
+++ b/frontend/src/components/FormationCard.tsx
@@ -1,0 +1,21 @@
+import { Formation } from "@/types/formation";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+interface FormationCardProps {
+  formation: Formation;
+}
+
+export default function FormationCard({ formation }: FormationCardProps) {
+  return (
+    <Card className="flex flex-col gap-2">
+      <CardHeader>
+        <CardTitle>{formation.name}</CardTitle>
+      </CardHeader>
+      {formation.description && (
+        <CardContent className="text-sm whitespace-pre-wrap">
+          <p>{formation.description}</p>
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/PlayerCard.tsx
+++ b/frontend/src/components/PlayerCard.tsx
@@ -1,0 +1,38 @@
+import { Player } from "@/types/player";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface PlayerCardProps {
+  player: Player;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export default function PlayerCard({ player, onEdit, onDelete }: PlayerCardProps) {
+  return (
+    <Card className="flex flex-col gap-2">
+      <CardHeader className="flex items-start justify-between gap-2">
+        <CardTitle>{player.name}</CardTitle>
+        <div className="flex gap-2">
+          {onEdit && (
+            <Button variant="outline" size="sm" onClick={onEdit}>
+              Editar
+            </Button>
+          )}
+          {onDelete && (
+            <Button variant="destructive" size="sm" onClick={onDelete}>
+              Eliminar
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="text-sm whitespace-pre-wrap break-all">
+        {player.stats ? (
+          <pre>{JSON.stringify(player.stats, null, 2)}</pre>
+        ) : (
+          <p>Sin estadísticas</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -7,6 +7,8 @@ import {
 import { useState } from "react"
 import Spinner from "@/components/ui/spinner"
 import PlayerWizard from "@/components/PlayerWizard"
+import PlayerCard from "@/components/PlayerCard"
+import { Button } from "@/components/ui/button"
 
 export default function Players() {
   const { data: players, isLoading: loading, error } = usePlayers()
@@ -35,53 +37,29 @@ export default function Players() {
   if (error) return <p className="text-red-500 text-center mt-10">{error}</p>
 
   return (
-    <div className="p-6">
-      <h2 className="text-xl font-bold mb-4">Jugadores</h2>
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-bold">Jugadores</h2>
 
-      <button
-        onClick={() => setShowModal(true)}
-        className="bg-green-600 text-white px-4 py-2 rounded mb-4"
-      >
+      <Button onClick={() => setShowModal(true)} className="w-fit">
         Crear jugador
-      </button>
+      </Button>
 
-      <table className="w-full border">
-        <thead>
-          <tr className="bg-gray-100">
-            <th className="p-2 text-left">Nombre</th>
-            <th className="p-2 text-left">Stats</th>
-          </tr>
-        </thead>
-        <tbody>
-          {players.map((player) => (
-            <tr key={player.id} className="border-t">
-              <td className="p-2">
-                {player.name}
-                <button
-                  onClick={() => {
-                    setName(player.name)
-                    setStats(JSON.stringify(player.stats, null, 2))
-                    setEditId(player.id)
-                    setIsEditMode(true)
-                    setShowModal(true)
-                  }}
-                  className="ml-2 text-blue-600 underline text-sm"
-                >
-                  Editar
-                </button>
-                <button
-                  onClick={() => handleDelete(player.id)}
-                  className="ml-2 text-red-600 underline text-sm"
-                >
-                  Eliminar
-                </button>
-              </td>
-              <td className="p-2">{JSON.stringify(player.stats)}</td>
-            </tr>
-          ))}
-
-        </tbody>
-      </table>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {players.map((player) => (
+          <PlayerCard
+            key={player.id}
+            player={player}
+            onEdit={() => {
+              setName(player.name)
+              setStats(JSON.stringify(player.stats, null, 2))
+              setEditId(player.id)
+              setIsEditMode(true)
+              setShowModal(true)
+            }}
+            onDelete={() => handleDelete(player.id)}
+          />
+        ))}
+      </div>
 
       {showModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/frontend/src/pages/Tactics.tsx
+++ b/frontend/src/pages/Tactics.tsx
@@ -5,6 +5,8 @@ import {
 } from "@/hooks/useFormations";
 import Spinner from "@/components/ui/spinner";
 import FormationWizard from "@/components/FormationWizard";
+import FormationCard from "@/components/FormationCard";
+import { Button } from "@/components/ui/button";
 
 export default function Tactics() {
   const { data: formations, isLoading, error } = useFormations();
@@ -20,21 +22,16 @@ export default function Tactics() {
   if (error) return <p className="text-red-500 text-center mt-10">{error}</p>;
 
   return (
-    <div className="p-6">
-      <h2 className="text-xl font-bold mb-4">Formaciones</h2>
-      <button
-        onClick={() => setShowWizard(true)}
-        className="bg-green-600 text-white px-4 py-2 rounded mb-4"
-      >
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-bold">Formaciones</h2>
+      <Button onClick={() => setShowWizard(true)} className="w-fit">
         Crear formaci\u00f3n
-      </button>
-      <ul>
+      </Button>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {formations.map((f) => (
-          <li key={f.id} className="border-b py-2">
-            {f.name}
-          </li>
+          <FormationCard key={f.id} formation={f} />
         ))}
-      </ul>
+      </div>
       {showWizard && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <FormationWizard


### PR DESCRIPTION
## Summary
- add reusable PlayerCard and FormationCard components
- display players and formations in card grids
- apply consistent button styles and spacing for readability

## Testing
- `pytest -q` in `ia-service`
- `npm test --silent` in `backend`
- `npm test --silent -- --run` in `frontend`