### PR TITLE
Add color palette guidelines and variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Tecnologías utilizadas:
 
 - Backend: NestJS, TypeORM, PostgreSQL
 - Frontend: React, Vite, TailwindCSS, shadcn/ui
+- Guía de colores: [frontend/COLOR_GUIDE.md](frontend/COLOR_GUIDE.md)
 - IA: FastAPI (Python)
 - Infraestructura: Docker Compose
 - CI/CD: GitHub Actions

--- a/frontend/COLOR_GUIDE.md
+++ b/frontend/COLOR_GUIDE.md
@@ -1,0 +1,21 @@
+# Guía de colores
+
+Esta aplicación utiliza una paleta sencilla para mantener la coherencia visual.
+
+## Colores base
+- **Primario** (`#1d4ed8`): se usa para acciones principales y elementos destacados.
+- **Secundario** (`#047857`): para resaltar información o acciones secundarias.
+- **Acento** (`#ca8a04`): utilizado para acentos y detalles.
+
+## Estados
+- **Éxito** (`#16a34a`)
+- **Advertencia** (`#d97706`)
+- **Error** (`#dc2626`)
+
+Siempre que se muestre un estado se acompaña de íconos o texto explicativo para mayor claridad.
+
+## Tonos neutros
+Se emplean tonos neutros claros para fondos y tarjetas, adaptados automáticamente al modo claro u oscuro.
+
+## Modo oscuro
+La paleta se ajusta cuando el usuario habilita el modo oscuro, manteniendo la legibilidad de texto e iconos.

--- a/frontend/src/components/FormationWizard.tsx
+++ b/frontend/src/components/FormationWizard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Spinner from "@/components/ui/spinner";
+import { Button } from "@/components/ui/button";
 
 export interface FormationWizardData {
   name: string;
@@ -81,30 +82,31 @@ export default function FormationWizard({
       )}
       <div className="flex justify-between mt-4">
         {step > 1 ? (
-          <button onClick={prev} className="text-blue-600 underline">
+          <Button variant="link" onClick={prev} className="text-primary">
             Atr\u00e1s
-          </button>
+          </Button>
         ) : (
           <span />
         )}
         {step < totalSteps && (
-          <button onClick={next} className="bg-blue-700 text-white px-4 py-2 rounded">
+          <Button variant="primary" onClick={next}>
             Siguiente
-          </button>
+          </Button>
         )}
         {step === totalSteps && (
-          <button
+          <Button
+            variant="success"
             onClick={finish}
             disabled={saving}
-            className="bg-green-700 text-white px-4 py-2 rounded flex items-center"
+            className="flex items-center"
           >
             {saving && <Spinner className="h-4 w-4 mr-2 text-white" />}
             Guardar
-          </button>
+          </Button>
         )}
-        <button onClick={onCancel} className="ml-2 text-red-600 underline">
+        <Button variant="link" onClick={onCancel} className="ml-2 text-destructive">
           Cancelar
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/PlayerWizard.tsx
+++ b/frontend/src/components/PlayerWizard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Spinner from "@/components/ui/spinner";
+import { Button } from "@/components/ui/button";
 
 export interface PlayerWizardData {
   name: string;
@@ -122,26 +123,24 @@ export default function PlayerWizard({
           <span />
         )}
         {step < totalSteps && (
-          <button
-            onClick={next}
-            className="bg-blue-700 text-white px-4 py-2 rounded"
-          >
+          <Button variant="primary" onClick={next}>
             Siguiente
-          </button>
+          </Button>
         )}
         {step === totalSteps && (
-          <button
+          <Button
+            variant="success"
             onClick={finish}
             disabled={saving}
-            className="bg-green-700 text-white px-4 py-2 rounded flex items-center"
+            className="flex items-center"
           >
             {saving && <Spinner className="h-4 w-4 mr-2 text-white" />}
             Guardar
-          </button>
+          </Button>
         )}
-        <button onClick={onCancel} className="ml-2 text-red-600 underline">
+        <Button variant="link" onClick={onCancel} className="ml-2 text-destructive">
           Cancelar
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -17,6 +17,10 @@ const buttonVariants = cva(
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        success:
+          "bg-success text-success-foreground shadow-xs hover:bg-success/80",
+        warning:
+          "bg-warning text-warning-foreground shadow-xs hover:bg-warning/80",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,6 +29,10 @@
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-destructive: var(--destructive);
   --color-border: var(--border);
   --color-input: var(--input);
@@ -64,6 +68,10 @@
   --muted-foreground: oklch(0.554 0.046 257.417);
   --accent: #ca8a04;
   --accent-foreground: #000000;
+  --success: #16a34a;
+  --success-foreground: #ffffff;
+  --warning: #d97706;
+  --warning-foreground: #ffffff;
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.929 0.013 255.508);
   --input: oklch(0.929 0.013 255.508);
@@ -98,6 +106,10 @@
   --muted-foreground: oklch(0.704 0.04 256.788);
   --accent: #ca8a04;
   --accent-foreground: #000000;
+  --success: #16a34a;
+  --success-foreground: #ffffff;
+  --warning: #d97706;
+  --warning-foreground: #ffffff;
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { logout } from "@/services/authService"
 import { useNavigate } from "react-router-dom"
 import { motion } from "framer-motion"
+import { Button } from "@/components/ui/button"
 
 export default function Dashboard() {
   const navigate = useNavigate()
@@ -18,12 +19,9 @@ export default function Dashboard() {
     >
       <h1 className="text-2xl font-bold">Bienvenido al Dashboard</h1>
       <p>Estás autenticado correctamente.</p>
-      <button
-        onClick={handleLogout}
-        className="bg-red-700 text-white px-4 py-2 rounded"
-      >
+      <Button variant="destructive" onClick={handleLogout}>
         Cerrar sesión
-      </button>
+      </Button>
     </motion.div>
   )
 }

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { register } from "@/services/authService"
 import Spinner from "@/components/ui/spinner"
+import { Button } from "@/components/ui/button"
 
 export default function Register() {
   const [name, setName] = useState("")
@@ -68,14 +69,15 @@ export default function Register() {
           aria-label="Contraseña"
         />
       </div>
-      {error && <p className="text-red-500">{error}</p>}
-      <button
-        className="bg-green-700 text-white px-4 py-2 rounded w-full flex items-center justify-center"
+      {error && <p className="text-destructive">{error}</p>}
+      <Button
+        variant="success"
+        className="w-full flex items-center justify-center"
         disabled={loading}
       >
         {loading && <Spinner className="mr-2 h-5 w-5 text-white" />}
         Crear cuenta
-      </button>
+      </Button>
     </form>
   )
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,6 +10,9 @@ export default {
         primary: 'oklch(0.65 0.18 145)',
         secondary: 'oklch(0.72 0.14 195)',
         accent: 'oklch(0.82 0.09 95)',
+        success: '#16a34a',
+        warning: '#d97706',
+        error: '#dc2626',
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- expand color palette variables for success and warning states
- add custom colors to Tailwind config
- update UI button component with new variants
- refactor wizards and pages to use color variants
- document palette in `COLOR_GUIDE.md`
- reference the new guide in README

## Testing
- `npm test -- --run` in `frontend`
- `pytest -q` in `ia-service`
