### PR TITLE
Add tactical board and stats pages with new registration wizard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import PrivateRoute from "@/components/PrivateRoute"
 import Players from "@/pages/Players"
 import Tactics from "@/pages/Tactics"
 import Profile from "@/pages/Profile"
+import Stats from "@/pages/Stats"
 import { Toaster } from "sonner"
 import { Navigate } from "react-router-dom"
 import BottomNav from "@/components/BottomNav"
@@ -39,6 +40,14 @@ function App() {
           element={
             <PrivateRoute>
               <Tactics />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/stats"
+          element={
+            <PrivateRoute>
+              <Stats />
             </PrivateRoute>
           }
         />

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom'
-import { FaHome, FaUserFriends, FaUser, FaChessBoard } from 'react-icons/fa'
+import { FaHome, FaUserFriends, FaUser, FaChessBoard, FaChartBar } from 'react-icons/fa'
 
 export default function BottomNav() {
   return (
@@ -20,6 +20,10 @@ export default function BottomNav() {
       <NavLink to="/tactics" className="flex flex-col items-center" aria-label="Tácticas">
         <FaChessBoard className="mb-1" aria-hidden="true" />
         T\u00e1cticas
+      </NavLink>
+      <NavLink to="/stats" className="flex flex-col items-center" aria-label="Estadísticas">
+        <FaChartBar className="mb-1" aria-hidden="true" />
+        Stats
       </NavLink>
       <NavLink to="/profile" className="flex flex-col items-center" aria-label="Perfil">
         <FaUser className="mb-1" aria-hidden="true" />

--- a/frontend/src/components/TacticsBoard.tsx
+++ b/frontend/src/components/TacticsBoard.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react"
+
+interface PlayerPos {
+  id: string
+  name: string
+  x: number
+  y: number
+}
+
+const initialPlayers: PlayerPos[] = [
+  { id: "1", name: "1", x: 45, y: 80 },
+  { id: "2", name: "2", x: 45, y: 60 },
+  { id: "3", name: "3", x: 45, y: 40 },
+  { id: "4", name: "4", x: 30, y: 20 },
+  { id: "5", name: "5", x: 60, y: 20 },
+]
+
+export default function TacticsBoard() {
+  const [players, setPlayers] = useState(initialPlayers)
+  const [editing, setEditing] = useState<string | null>(null)
+  const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | null>(null)
+
+  const onDragStart = (e: React.DragEvent, id: string) => {
+    e.dataTransfer.setData("id", id)
+  }
+
+  const onDrop = (e: React.DragEvent) => {
+    const id = e.dataTransfer.getData("id")
+    const rect = e.currentTarget.getBoundingClientRect()
+    const x = ((e.clientX - rect.left) / rect.width) * 100
+    const y = ((e.clientY - rect.top) / rect.height) * 100
+    setPlayers((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, x, y } : p))
+    )
+  }
+
+  const handleLongPress = (id: string) => {
+    setEditing(id)
+  }
+
+  const startPress = (id: string) => {
+    const timer = setTimeout(() => handleLongPress(id), 500)
+    setPressTimer(timer)
+  }
+
+  const endPress = () => {
+    if (pressTimer) clearTimeout(pressTimer)
+  }
+
+  const savePos = (id: string, x: number, y: number) => {
+    setPlayers((prev) => prev.map((p) => (p.id === id ? { ...p, x, y } : p)))
+    setEditing(null)
+  }
+
+  return (
+    <div
+      className="relative w-full h-96 bg-green-700 rounded"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={onDrop}
+    >
+      {players.map((p) => (
+        <div
+          key={p.id}
+          draggable
+          onDragStart={(e) => onDragStart(e, p.id)}
+          onMouseDown={() => startPress(p.id)}
+          onMouseUp={endPress}
+          onTouchStart={() => startPress(p.id)}
+          onTouchEnd={endPress}
+          className="absolute text-white font-bold cursor-move select-none"
+          style={{ left: `${p.x}%`, top: `${p.y}%` }}
+        >
+          {p.name}
+          {editing === p.id && (
+            <div className="absolute left-1/2 top-full mt-1 -translate-x-1/2 bg-white text-black p-2 rounded shadow">
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  const form = e.target as HTMLFormElement
+                  const x = parseFloat((form.elements.namedItem("x") as HTMLInputElement).value)
+                  const y = parseFloat((form.elements.namedItem("y") as HTMLInputElement).value)
+                  savePos(p.id, x, y)
+                }}
+              >
+                <div className="flex gap-1">
+                  <input
+                    name="x"
+                    type="number"
+                    defaultValue={p.x.toFixed(1)}
+                    step="1"
+                    className="border px-1 w-16 text-sm"
+                  />
+                  <input
+                    name="y"
+                    type="number"
+                    defaultValue={p.y.toFixed(1)}
+                    step="1"
+                    className="border px-1 w-16 text-sm"
+                  />
+                  <button className="bg-blue-700 text-white px-2 rounded text-sm">OK</button>
+                </div>
+              </form>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -7,9 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import Spinner from "@/components/ui/spinner"
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
-
-export const Input: React.FC<InputProps> = (props) => {
+export const Input: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = (props) => {
   return (
     <input
       {...props}
@@ -37,7 +35,7 @@ export default function Login() {
       localStorage.setItem("token", res.data.token)
       toast.success("Inicio de sesión exitoso")
       navigate("/dashboard")
-    } catch (err) {
+    } catch {
       toast.error("Credenciales inválidas o error del servidor")
     } finally {
       setLoading(false)

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,81 +1,136 @@
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { register } from "@/services/authService"
+import { register as registerUser } from "@/services/authService"
 import Spinner from "@/components/ui/spinner"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
 
 export default function Register() {
+  const [step, setStep] = useState(1)
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
-  const [error, setError] = useState("")
+  const [team, setTeam] = useState("")
+  const [role, setRole] = useState("")
+  const [errors, setErrors] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(false)
   const navigate = useNavigate()
+  const totalSteps = 3
 
-  async function handleSubmit(e: React.FormEvent) {
+  function validateStep1() {
+    const e: Record<string, string> = {}
+    if (!name.trim()) e.name = "Nombre requerido"
+    if (!email.includes("@")) e.email = "Email inválido"
+    if (password.length < 6) e.password = "Mínimo 6 caracteres"
+    setErrors(e)
+    return Object.keys(e).length === 0
+  }
+
+  function validateStep2() {
+    const e: Record<string, string> = {}
+    if (!team.trim()) e.team = "Equipo requerido"
+    if (!role.trim()) e.role = "Posición requerida"
+    setErrors(e)
+    return Object.keys(e).length === 0
+  }
+
+  const next = () => {
+    if (step === 1 && !validateStep1()) return
+    if (step === 2 && !validateStep2()) return
+    setErrors({})
+    setStep((s) => Math.min(s + 1, totalSteps))
+  }
+
+  const prev = () => {
+    setErrors({})
+    setStep((s) => Math.max(s - 1, 1))
+  }
+
+  async function finish(e: React.FormEvent) {
     e.preventDefault()
-    setError("")
+    if (!validateStep1() || !validateStep2()) {
+      setStep(1)
+      return
+    }
     setLoading(true)
-
-    if (!name || !email || !password)
-      return setError("Todos los campos son obligatorios")
-
     try {
-      await register(name, email, password)
+      await registerUser(name, email, password)
       navigate("/login")
-    } catch (err) {
-      setError("No se pudo registrar el usuario")
+    } catch {
+      setErrors({ submit: "No se pudo registrar el usuario" })
     } finally {
       setLoading(false)
     }
   }
 
+  const progress = ((step - 1) / (totalSteps - 1)) * 100
+
   return (
-    <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-10 space-y-4">
-      <h1 className="text-xl font-bold">Registrarse</h1>
-      <div className="space-y-1">
-        <label htmlFor="name" className="text-sm font-medium">Nombre</label>
-        <input
-          id="name"
-          type="text"
-          placeholder="Nombre"
-          className="border p-2 w-full rounded"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          aria-label="Nombre"
-        />
+    <form onSubmit={finish} className="max-w-sm mx-auto mt-10 space-y-4">
+      <div className="h-2 bg-gray-200 rounded">
+        <div className="h-full bg-blue-700 rounded" style={{ width: `${progress}%` }} />
       </div>
-      <div className="space-y-1">
-        <label htmlFor="email" className="text-sm font-medium">Email</label>
-        <input
-          id="email"
-          type="email"
-          placeholder="Email"
-          className="border p-2 w-full rounded"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          aria-label="Email"
-        />
+      {step === 1 && (
+        <div className="space-y-3">
+          <h1 className="text-lg font-bold">Datos personales</h1>
+          <div>
+            <label htmlFor="name" className="text-sm font-medium">Nombre</label>
+            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+            {errors.name && <p className="text-red-500 text-sm">{errors.name}</p>}
+          </div>
+          <div>
+            <label htmlFor="email" className="text-sm font-medium">Email</label>
+            <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            {errors.email && <p className="text-red-500 text-sm">{errors.email}</p>}
+          </div>
+          <div>
+            <label htmlFor="password" className="text-sm font-medium">Contraseña</label>
+            <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+            {errors.password && <p className="text-red-500 text-sm">{errors.password}</p>}
+          </div>
+        </div>
+      )}
+      {step === 2 && (
+        <div className="space-y-3">
+          <h1 className="text-lg font-bold">Información de equipo</h1>
+          <div>
+            <label htmlFor="team" className="text-sm font-medium">Equipo</label>
+            <Input id="team" value={team} onChange={(e) => setTeam(e.target.value)} />
+            {errors.team && <p className="text-red-500 text-sm">{errors.team}</p>}
+          </div>
+          <div>
+            <label htmlFor="role" className="text-sm font-medium">Posición</label>
+            <Input id="role" value={role} onChange={(e) => setRole(e.target.value)} />
+            {errors.role && <p className="text-red-500 text-sm">{errors.role}</p>}
+          </div>
+        </div>
+      )}
+      {step === 3 && (
+        <div className="space-y-2">
+          <h1 className="text-lg font-bold">Confirmar datos</h1>
+          <p><strong>Nombre:</strong> {name}</p>
+          <p><strong>Email:</strong> {email}</p>
+          <p><strong>Equipo:</strong> {team}</p>
+          <p><strong>Posición:</strong> {role}</p>
+          {errors.submit && <p className="text-red-500 text-sm">{errors.submit}</p>}
+        </div>
+      )}
+      <div className="flex justify-between pt-2">
+        {step > 1 ? (
+          <Button type="button" variant="outline" onClick={prev}>Atrás</Button>
+        ) : (
+          <span />
+        )}
+        {step < totalSteps && (
+          <Button type="button" onClick={next}>Siguiente</Button>
+        )}
+        {step === totalSteps && (
+          <Button type="submit" disabled={loading} className="flex items-center justify-center">
+            {loading && <Spinner className="mr-2 h-4 w-4 text-white" />}
+            Completar
+          </Button>
+        )}
       </div>
-      <div className="space-y-1">
-        <label htmlFor="password" className="text-sm font-medium">Contraseña</label>
-        <input
-          id="password"
-          type="password"
-          placeholder="Contraseña"
-          className="border p-2 w-full rounded"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          aria-label="Contraseña"
-        />
-      </div>
-      {error && <p className="text-red-500">{error}</p>}
-      <button
-        className="bg-green-700 text-white px-4 py-2 rounded w-full flex items-center justify-center"
-        disabled={loading}
-      >
-        {loading && <Spinner className="mr-2 h-5 w-5 text-white" />}
-        Crear cuenta
-      </button>
     </form>
   )
 }

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react"
+import {
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts"
+import { Button } from "@/components/ui/button"
+
+interface StatItem {
+  name: string
+  value: number
+}
+
+const monthData: StatItem[] = [
+  { name: "Goles", value: 3 },
+  { name: "Asistencias", value: 2 },
+  { name: "Pases", value: 55 },
+]
+
+const seasonData: StatItem[] = [
+  { name: "Goles", value: 12 },
+  { name: "Asistencias", value: 7 },
+  { name: "Pases", value: 240 },
+]
+
+export default function Stats() {
+  const [range, setRange] = useState<"month" | "season">("month")
+  const data = range === "month" ? monthData : seasonData
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-bold">Rendimiento</h2>
+      <div className="flex gap-2">
+        <Button
+          variant={range === "month" ? "default" : "outline"}
+          onClick={() => setRange("month")}
+        >
+          Último mes
+        </Button>
+        <Button
+          variant={range === "season" ? "default" : "outline"}
+          onClick={() => setRange("season")}
+        >
+          Temporada
+        </Button>
+      </div>
+      <div className="flex flex-col md:flex-row gap-8">
+        <BarChart width={300} height={200} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="value" fill="#8884d8" />
+        </BarChart>
+        <RadarChart width={300} height={250} data={data}>
+          <PolarGrid />
+          <PolarAngleAxis dataKey="name" />
+          <PolarRadiusAxis />
+          <Radar
+            name="Estadísticas"
+            dataKey="value"
+            stroke="#82ca9d"
+            fill="#82ca9d"
+            fillOpacity={0.6}
+          />
+        </RadarChart>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Tactics.tsx
+++ b/frontend/src/pages/Tactics.tsx
@@ -7,6 +7,7 @@ import Spinner from "@/components/ui/spinner";
 import FormationWizard from "@/components/FormationWizard";
 import FormationCard from "@/components/FormationCard";
 import { Button } from "@/components/ui/button";
+import TacticsBoard from "@/components/TacticsBoard";
 
 export default function Tactics() {
   const { data: formations, isLoading, error } = useFormations();
@@ -32,6 +33,7 @@ export default function Tactics() {
           <FormationCard key={f.id} formation={f} />
         ))}
       </div>
+      <TacticsBoard />
       {showWizard && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <FormationWizard


### PR DESCRIPTION
## Summary
- implement 3-step registration wizard with validation
- add interactive tactics board with drag & drop players
- show performance stats with bar and radar charts
- route new pages and update bottom navigation
- minor cleanup in login page

## Testing
- `npm run lint` in `frontend`
- `npm run test` in `frontend`
- `npm run lint` in `backend`
- `npm test` in `backend`