### PR TITLE
Implementar pantalla de inicio resumida

### DIFF
--- a/frontend/src/components/PlayerQuickInfo.tsx
+++ b/frontend/src/components/PlayerQuickInfo.tsx
@@ -1,0 +1,47 @@
+import { Player } from "@/types/player";
+import { useState } from "react";
+
+interface PlayerQuickInfoProps {
+  player: Player;
+}
+
+export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
+  const [tab, setTab] = useState<'stats' | 'history' | 'notes'>('stats');
+
+  return (
+    <div className="bg-white p-4 rounded shadow w-80">
+      <h3 className="text-lg font-bold mb-2">{player.name}</h3>
+      <div className="flex gap-2 mb-2">
+        <button
+          className={`px-2 py-1 rounded ${tab === 'stats' ? 'bg-blue-700 text-white' : 'bg-gray-200'}`}
+          onClick={() => setTab('stats')}
+        >
+          Estadísticas
+        </button>
+        <button
+          className={`px-2 py-1 rounded ${tab === 'history' ? 'bg-blue-700 text-white' : 'bg-gray-200'}`}
+          onClick={() => setTab('history')}
+        >
+          Historial
+        </button>
+        <button
+          className={`px-2 py-1 rounded ${tab === 'notes' ? 'bg-blue-700 text-white' : 'bg-gray-200'}`}
+          onClick={() => setTab('notes')}
+        >
+          Notas
+        </button>
+      </div>
+      {tab === 'stats' && (
+        <pre className="whitespace-pre-wrap break-all text-sm">
+          {player.stats ? JSON.stringify(player.stats, null, 2) : 'Sin estadísticas'}
+        </pre>
+      )}
+      {tab === 'history' && (
+        <p className="text-sm text-gray-600">Historial no disponible.</p>
+      )}
+      {tab === 'notes' && (
+        <p className="text-sm text-gray-600">Notas no disponibles.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useMatches.ts
+++ b/frontend/src/hooks/useMatches.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { Match } from "@/types/match";
+import { getMatches } from "@/services/matches";
+
+export function useMatches() {
+  return useQuery<Match[]>({
+    queryKey: ["matches"],
+    queryFn: getMatches,
+  });
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,9 +1,29 @@
 import { logout } from "@/services/authService"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, Link } from "react-router-dom"
 import { motion } from "framer-motion"
+import { usePlayers } from "@/hooks/usePlayers"
+import { useMatches } from "@/hooks/useMatches"
+import Spinner from "@/components/ui/spinner"
+import PlayerQuickInfo from "@/components/PlayerQuickInfo"
+import { useState } from "react"
 
 export default function Dashboard() {
   const navigate = useNavigate()
+  const { data: players, isLoading: playersLoading } = usePlayers()
+  const { data: matches, isLoading: matchesLoading } = useMatches()
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const upcoming = matches
+    ? [...matches]
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+        .slice(0, 3)
+    : []
+
+  const averageScore = players && players.length
+    ? (
+        players.reduce((sum, p) => sum + (p.score || 0), 0) / players.length
+      ).toFixed(2)
+    : 'N/A'
 
   function handleLogout() {
     logout()
@@ -17,11 +37,80 @@ export default function Dashboard() {
       animate={{ opacity: 1, y: 0 }}
     >
       <h1 className="text-2xl font-bold">Bienvenido al Dashboard</h1>
-      <p>Estás autenticado correctamente.</p>
-      <button
-        onClick={handleLogout}
-        className="bg-red-700 text-white px-4 py-2 rounded"
-      >
+
+      <div className="flex gap-4 overflow-x-auto pb-4">
+        <div className="min-w-[15rem] bg-white rounded shadow p-4">
+          <h2 className="font-bold mb-2">Próximos partidos</h2>
+          {matchesLoading ? (
+            <Spinner className="h-4 w-4 text-primary" />
+          ) : upcoming.length ? (
+            <ul className="space-y-1">
+              {upcoming.map((m) => (
+                <li key={m.id}>{new Date(m.date).toLocaleDateString()}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-600">Sin partidos</p>
+          )}
+        </div>
+        <div className="min-w-[15rem] bg-white rounded shadow p-4">
+          <h2 className="font-bold mb-2">Promedio de rendimiento</h2>
+          {playersLoading ? (
+            <Spinner className="h-4 w-4 text-primary" />
+          ) : (
+            <p className="text-2xl font-semibold">{averageScore}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-4">
+        <Link
+          to="/tactics"
+          className="flex-1 bg-blue-700 text-white text-center py-3 rounded text-lg"
+        >
+          Crear formación
+        </Link>
+        <Link
+          to="/players"
+          className="flex-1 bg-green-700 text-white text-center py-3 rounded text-lg"
+        >
+          Analizar rendimiento
+        </Link>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-bold mb-2">Jugadores</h2>
+        {playersLoading ? (
+          <Spinner className="h-6 w-6 text-primary" />
+        ) : (
+          <div className="flex gap-2 overflow-x-auto pb-2">
+            {players?.map((p) => (
+              <button
+                key={p.id}
+                onClick={() => setSelected(p.id)}
+                className="min-w-40 bg-white rounded shadow p-2 text-left"
+              >
+                {p.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {selected && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white p-4 rounded">
+            <PlayerQuickInfo player={players!.find((p) => p.id === selected)!} />
+            <div className="text-right mt-2">
+              <button onClick={() => setSelected(null)} className="text-blue-700 underline">
+                Cerrar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <button onClick={handleLogout} className="bg-red-700 text-white px-4 py-2 rounded">
         Cerrar sesión
       </button>
     </motion.div>

--- a/frontend/src/services/matches.ts
+++ b/frontend/src/services/matches.ts
@@ -1,0 +1,7 @@
+import api from "./api";
+import { Match } from "../types/match";
+
+export async function getMatches(): Promise<Match[]> {
+  const res = await api.get("/matches");
+  return res.data;
+}

--- a/frontend/src/types/match.ts
+++ b/frontend/src/types/match.ts
@@ -1,0 +1,4 @@
+export interface Match {
+  id: string;
+  date: string;
+}


### PR DESCRIPTION
## Summary
- añadir API y hook para obtener partidos
- mostrar resumen y botones destacados en `Dashboard`
- permitir vista rápida del jugador

## Testing
- `npm test` en `backend`
- `npm test` en `frontend`
