### PR TITLE
Add dark mode toggle

### DIFF
--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,5 +1,12 @@
 import { NavLink } from 'react-router-dom'
-import { FaHome, FaUserFriends, FaUser, FaChessBoard, FaChartBar } from 'react-icons/fa'
+import {
+  FaHome,
+  FaUserFriends,
+  FaUser,
+  FaChessBoard,
+  FaChartBar,
+} from 'react-icons/fa'
+import ThemeToggle from './ThemeToggle'
 
 export default function BottomNav() {
   return (
@@ -29,6 +36,7 @@ export default function BottomNav() {
         <FaUser className="mb-1" aria-hidden="true" />
         Perfil
       </NavLink>
+      <ThemeToggle />
     </nav>
   )
 }

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { FaMoon, FaSun } from 'react-icons/fa'
+import { Button } from './ui/button'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    const saved = localStorage.getItem('theme') as 'light' | 'dark' | null
+    if (saved) return saved
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+  })
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light')
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label={
+        theme === 'light' ? 'Activar modo oscuro' : 'Desactivar modo oscuro'
+      }
+    >
+      {theme === 'light' ? <FaMoon aria-hidden="true" /> : <FaSun aria-hidden="true" />}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce `ThemeToggle` to persist user theme preference
- expose dark/light switch in `BottomNav`

## Testing
- `npm run test` in `backend`
- `npm run test` in `frontend`
