### PR TITLE
Add average rating endpoint

### DIFF
--- a/backend/src/modules/players/__tests__/players.controller.spec.ts
+++ b/backend/src/modules/players/__tests__/players.controller.spec.ts
@@ -22,6 +22,7 @@ describe('PlayersController', () => {
             create: jest.fn(),
             update: jest.fn(),
             remove: jest.fn(),
+            getAverageRating: jest.fn(),
           },
         },
       ],
@@ -49,5 +50,10 @@ describe('PlayersController', () => {
   it('searches players by position', () => {
     controller.searchByPosition('forward');
     expect(service.searchByPosition).toHaveBeenCalledWith('forward');
+  });
+
+  it('gets average rating', () => {
+    controller.getAverageRating('id');
+    expect(service.getAverageRating).toHaveBeenCalledWith('id');
   });
 });

--- a/backend/src/modules/players/__tests__/players.service.spec.ts
+++ b/backend/src/modules/players/__tests__/players.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, EntityNotFoundError } from 'typeorm';
 import { PlayersService } from '../players.service';
 import { Player } from '../player.entity';
+import { RatingsService } from '../../ratings/ratings.service';
 
 describe('PlayersService', () => {
   let service: PlayersService;
@@ -12,6 +13,7 @@ describe('PlayersService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PlayersService,
+        { provide: RatingsService, useValue: { averageForPlayer: jest.fn() } },
         {
           provide: getRepositoryToken(Player),
           useValue: {

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -38,6 +38,14 @@ export class PlayersController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get(':id/average-rating')
+  getAverageRating(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ) {
+    return this.playersService.getAverageRating(id);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get(":id")
   async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
     return this.playersService.findOne(id);

--- a/backend/src/modules/players/players.module.ts
+++ b/backend/src/modules/players/players.module.ts
@@ -4,10 +4,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Player } from './player.entity';
 import { PlayersService } from './players.service';
 import { PlayersController } from './players.controller';
+import { RatingsModule } from '../ratings/ratings.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Player]),
+    RatingsModule,
   ],
   providers: [
     PlayersService,

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -2,11 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, ILike } from 'typeorm';
 import { Player } from './player.entity';
+import { RatingsService } from '../ratings/ratings.service';
 
 @Injectable()
 export class PlayersService {
   constructor(
     @InjectRepository(Player) private playersRepo: Repository<Player>,
+    private readonly ratingsService: RatingsService,
   ) {}
 
   create(data: Partial<Player>): Promise<Player> {
@@ -39,5 +41,9 @@ export class PlayersService {
     const player = await this.playersRepo.findOneByOrFail({ id });
     await this.playersRepo.remove(player);
     return player;
+  }
+
+  getAverageRating(id: string): Promise<number> {
+    return this.ratingsService.averageForPlayer(id);
   }
 }

--- a/backend/src/modules/ratings/ratings.module.ts
+++ b/backend/src/modules/ratings/ratings.module.ts
@@ -10,6 +10,7 @@ import { Player } from '../players/player.entity';
   imports: [TypeOrmModule.forFeature([Rating, Match, Player])],
   providers: [RatingsService],
   controllers: [RatingsController],
+  exports: [RatingsService],
 })
 export class RatingsModule {}
 

--- a/backend/src/modules/ratings/ratings.service.ts
+++ b/backend/src/modules/ratings/ratings.service.ts
@@ -41,5 +41,15 @@ export class RatingsService {
       return manager.save(rating);
     });
   }
+
+  async averageForPlayer(playerId: string): Promise<number> {
+    const result = await this.ratingsRepo
+      .createQueryBuilder('rating')
+      .select('AVG(rating.score)', 'avg')
+      .where('rating.playerId = :playerId', { playerId })
+      .getRawOne<{ avg: string | null }>();
+    const avg = result?.avg;
+    return avg ? parseFloat(avg) : 0;
+  }
 }
 


### PR DESCRIPTION
## Summary
- expose new `GET /players/:id/average-rating` endpoint
- compute average rating for a player
- wire players module with ratings module
- update unit tests

## Testing
- `cd backend && npm test --silent`