### PR TITLE
Implement global error handling

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -32,6 +32,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setAuthToken(null)
   }
 
+  useEffect(() => {
+    const handler = () => logout()
+    window.addEventListener('unauthorized', handler)
+    return () => window.removeEventListener('unauthorized', handler)
+  }, [logout])
+
   return (
     <AuthContext.Provider value={{ token, isAuthenticated: !!token, login, logout }}>
       {children}

--- a/frontend/src/hooks/useFormations.ts
+++ b/frontend/src/hooks/useFormations.ts
@@ -27,7 +27,7 @@ export const useCreateFormation = () => {
       queryClient.invalidateQueries({ queryKey: ["formations"] });
     },
     onError: () => {
-      toast.error("Error al crear formaci\u00f3n");
+      // handled globally
     },
   });
 };

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -32,7 +32,7 @@ export const useCreatePlayer = () => {
       queryClient.invalidateQueries({ queryKey: ["players"] })
     },
     onError: () => {
-      toast.error("Error al crear el jugador")
+      // handled globally
     },
   })
 }
@@ -49,7 +49,7 @@ export const useUpdatePlayer = () => {
       queryClient.invalidateQueries({ queryKey: ["players"] })
     },
     onError: () => {
-      toast.error("Error al actualizar el jugador")
+      // handled globally
     },
   })
 }
@@ -66,7 +66,7 @@ export const useDeletePlayer = () => {
       queryClient.invalidateQueries({ queryKey: ["players"] })
     },
     onError: () => {
-      toast.error("Error al eliminar el jugador")
+      // handled globally
     },
   })
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,15 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { AuthProvider } from './context/AuthContext'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from './queryClient'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </AuthProvider>
   </StrictMode>,
 )

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -1,0 +1,31 @@
+import { QueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import axios from 'axios'
+
+const getMessage = (error: unknown) => {
+  if (axios.isAxiosError(error)) {
+    return (
+      (error.response?.data as { message?: string })?.message ||
+      error.message ||
+      'Error inesperado'
+    )
+  }
+  if (error instanceof Error) return error.message
+  return 'Error inesperado'
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      onError: (error) => {
+        toast.error(getMessage(error))
+      },
+    },
+    mutations: {
+      onError: (error) => {
+        toast.error(getMessage(error))
+      },
+    },
+  },
+})

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -20,4 +20,16 @@ api.interceptors.request.use((config) => {
   return config
 })
 
+api.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    if (error.response?.status === 401) {
+      setAuthToken(null)
+      window.dispatchEvent(new Event('unauthorized'))
+      window.location.href = '/login'
+    }
+    return Promise.reject(error)
+  },
+)
+
 export default api


### PR DESCRIPTION
## Summary
- create a `QueryClient` with default error toasts
- wrap app with `QueryClientProvider`
- use Axios response interceptor to logout and redirect on 401
- handle `unauthorized` event in `AuthContext`
- rely on global error toast logic in player and formation hooks

## Testing
- `npm test`
- `npm run lint`