### PR TITLE
Improve UI tests & lazy load pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,18 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom"
-import Login from "@/pages/Login"
-import Dashboard from "@/pages/Dashboard"
-import Register from "@/pages/Register"
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
+import { lazy, Suspense } from "react"
 import PrivateRoute from "@/components/PrivateRoute"
-import Players from "@/pages/Players"
-import Tactics from "@/pages/Tactics"
-import Profile from "@/pages/Profile"
-import Stats from "@/pages/Stats"
-import { Toaster } from "sonner"
-import { Navigate } from "react-router-dom"
 import BottomNav from "@/components/BottomNav"
 import { useAuth } from "@/context/AuthContext"
+import Spinner from "@/components/ui/spinner"
+import { Toaster } from "sonner"
+
+const Login = lazy(() => import("@/pages/Login"))
+const Register = lazy(() => import("@/pages/Register"))
+const Dashboard = lazy(() => import("@/pages/Dashboard"))
+const Players = lazy(() => import("@/pages/Players"))
+const Tactics = lazy(() => import("@/pages/Tactics"))
+const Profile = lazy(() => import("@/pages/Profile"))
+const Stats = lazy(() => import("@/pages/Stats"))
 
 function App() {
   const { isAuthenticated } = useAuth()
@@ -18,48 +20,72 @@ function App() {
     <>
       <BrowserRouter>
         <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
+          <Route
+            path="/login"
+            element={
+              <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}> 
+                <Login />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/register"
+            element={
+              <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}> 
+                <Register />
+              </Suspense>
+            }
+          />
           <Route
             path="/dashboard"
             element={
               <PrivateRoute>
-                <Dashboard />
+                <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}> 
+                  <Dashboard />
+                </Suspense>
               </PrivateRoute>
             }
           />
-        <Route
-          path="/players"
-          element={
-            <PrivateRoute>
-              <Players />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/tactics"
-          element={
-            <PrivateRoute>
-              <Tactics />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/stats"
-          element={
-            <PrivateRoute>
-              <Stats />
-            </PrivateRoute>
-          }
-        />
-        <Route
-          path="/profile"
-          element={
-            <PrivateRoute>
-              <Profile />
-            </PrivateRoute>
-          }
-        />
+          <Route
+            path="/players"
+            element={
+              <PrivateRoute>
+                <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}> 
+                  <Players />
+                </Suspense>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/tactics"
+            element={
+              <PrivateRoute>
+                <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}> 
+                  <Tactics />
+                </Suspense>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/stats"
+            element={
+              <PrivateRoute>
+                <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}> 
+                  <Stats />
+                </Suspense>
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/profile"
+            element={
+              <PrivateRoute>
+                <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}> 
+                  <Profile />
+                </Suspense>
+              </PrivateRoute>
+            }
+          />
           <Route path="*" element={<Navigate to="/login" />} />
         </Routes>
         {isAuthenticated && <BottomNav />}

--- a/frontend/src/components/PlayerQuickInfo.test.tsx
+++ b/frontend/src/components/PlayerQuickInfo.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import PlayerQuickInfo from './PlayerQuickInfo'
+
+describe('PlayerQuickInfo', () => {
+  const player = { id: '1', name: 'Test Player', stats: { goals: 5 } }
+
+  it('switches between tabs', () => {
+    render(<PlayerQuickInfo player={player} />)
+
+    // shows stats by default
+    expect(screen.getByText(/goals/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText(/Historial/i))
+    expect(screen.getByText(/Historial no disponible/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText(/Notas/i))
+    expect(screen.getByText(/Notas no disponibles/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Register.test.tsx
+++ b/frontend/src/pages/Register.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MemoryRouter } from 'react-router-dom'
+import Register from './Register'
+import { vi } from 'vitest'
+
+vi.mock('@/services/authService', () => ({
+  register: vi.fn(),
+}))
+
+import { register as mockRegister } from '@/services/authService'
+
+describe('Register page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('validates step 1 before proceeding', () => {
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByText(/siguiente/i))
+    expect(screen.getByText('Nombre requerido')).toBeInTheDocument()
+    expect(screen.getByText('Email inválido')).toBeInTheDocument()
+    expect(screen.getByText('Mínimo 6 caracteres')).toBeInTheDocument()
+  })
+
+  it('completes registration flow', async () => {
+    ;(mockRegister as vi.Mock).mockResolvedValueOnce({})
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    )
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Test' } })
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } })
+    fireEvent.change(screen.getByLabelText('Contraseña'), { target: { value: '123456' } })
+    fireEvent.click(screen.getByText(/siguiente/i))
+
+    fireEvent.change(screen.getByLabelText('Equipo'), { target: { value: 'Team' } })
+    fireEvent.change(screen.getByLabelText('Posición'), { target: { value: 'Forward' } })
+    fireEvent.click(screen.getByText(/siguiente/i))
+
+    fireEvent.click(screen.getByText(/completar/i))
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledWith('Test', 'test@example.com', '123456')
+    })
+  })
+
+  it('shows error when registration fails', async () => {
+    ;(mockRegister as vi.Mock).mockRejectedValueOnce(new Error('fail'))
+    render(
+      <MemoryRouter>
+        <Register />
+      </MemoryRouter>
+    )
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Test' } })
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } })
+    fireEvent.change(screen.getByLabelText('Contraseña'), { target: { value: '123456' } })
+    fireEvent.click(screen.getByText(/siguiente/i))
+
+    fireEvent.change(screen.getByLabelText('Equipo'), { target: { value: 'Team' } })
+    fireEvent.change(screen.getByLabelText('Posición'), { target: { value: 'Forward' } })
+    fireEvent.click(screen.getByText(/siguiente/i))
+
+    fireEvent.click(screen.getByText(/completar/i))
+
+    await waitFor(() => {
+      expect(screen.getByText('No se pudo registrar el usuario')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add lazy loaded pages and suspense fallback
- test register page including errors
- test PlayerQuickInfo tab switching

## Testing
- `cd frontend && npm test --silent`