### PR TITLE
Refactor authService to use API client

### DIFF
--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,36 +1,12 @@
-const API_URL = `${import.meta.env.VITE_API_URL || "http://localhost:3000"}/auth`;
+import api from './api'
 
 export async function login(email: string, password: string) {
-  const res = await fetch(`${API_URL}/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, password }),
-  });
-
-  if (!res.ok) throw new Error("Login failed");
-
-  const data = await res.json();
-  localStorage.setItem("token", data.token);
-  return data;
+  const res = await api.post('/auth/login', { email, password })
+  return res.data
 }
 
 export async function register(name: string, email: string, password: string) {
-  const res = await fetch(`${API_URL}/register`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, email, password }),
-  });
-
-  if (!res.ok) throw new Error("Registration failed");
-
-  const data = await res.json();
-  return data;
+  const res = await api.post('/auth/register', { name, email, password })
+  return res.data
 }
 
-export function logout() {
-  localStorage.removeItem("token");
-}
-
-export function isAuthenticated() {
-  return Boolean(localStorage.getItem("token"));
-}


### PR DESCRIPTION
## Summary
- refactor `authService.ts` to use axios API client
- drop localStorage access since `AuthContext` manages auth

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_b_6839f72339a083308c907a0a812dd5a8