### PR TITLE
Add stats fetching via React Query

### DIFF
--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getStats } from "@/services/stats";
+import { StatItem } from "@/types/stats";
+
+export function useStats(range: "month" | "season") {
+  return useQuery<StatItem[]>({
+    queryKey: ["stats", range],
+    queryFn: () => getStats(range),
+  });
+}

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -14,27 +14,26 @@ import {
   Legend,
 } from "recharts"
 import { Button } from "@/components/ui/button"
-
-interface StatItem {
-  name: string
-  value: number
-}
-
-const monthData: StatItem[] = [
-  { name: "Goles", value: 3 },
-  { name: "Asistencias", value: 2 },
-  { name: "Pases", value: 55 },
-]
-
-const seasonData: StatItem[] = [
-  { name: "Goles", value: 12 },
-  { name: "Asistencias", value: 7 },
-  { name: "Pases", value: 240 },
-]
+import { useStats } from "@/hooks/useStats"
+import Spinner from "@/components/ui/spinner"
 
 export default function Stats() {
   const [range, setRange] = useState<"month" | "season">("month")
-  const data = range === "month" ? monthData : seasonData
+  const { data, isLoading, error } = useStats(range)
+
+  const stats = data || []
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center mt-10">
+        <Spinner className="h-8 w-8 text-primary" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return <p className="text-red-500 text-center mt-10">{String(error)}</p>
+  }
 
   return (
     <div className="p-6 space-y-4">
@@ -54,7 +53,7 @@ export default function Stats() {
         </Button>
       </div>
       <div className="flex flex-col md:flex-row gap-8">
-        <BarChart width={300} height={200} data={data}>
+        <BarChart width={300} height={200} data={stats}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
@@ -62,7 +61,7 @@ export default function Stats() {
           <Legend />
           <Bar dataKey="value" fill="#8884d8" />
         </BarChart>
-        <RadarChart width={300} height={250} data={data}>
+        <RadarChart width={300} height={250} data={stats}>
           <PolarGrid />
           <PolarAngleAxis dataKey="name" />
           <PolarRadiusAxis />

--- a/frontend/src/services/stats.ts
+++ b/frontend/src/services/stats.ts
@@ -1,0 +1,7 @@
+import api from "./api";
+import { StatItem } from "@/types/stats";
+
+export async function getStats(range: "month" | "season"): Promise<StatItem[]> {
+  const res = await api.get(`/stats`, { params: { range } });
+  return res.data;
+}

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -1,0 +1,4 @@
+export interface StatItem {
+  name: string;
+  value: number;
+}


### PR DESCRIPTION
## Summary
- add `stats` API service and `useStats` hook
- wire up `Stats` page to use API data
- show loading spinner and error message states

## Testing
- `npx vitest run`
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_b_6839f72340388330a3c0d033483091b1