### PR TITLE
Add NotFound route to frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
+import { BrowserRouter, Routes, Route } from "react-router-dom"
 import { lazy, Suspense } from "react"
 import PrivateRoute from "@/components/PrivateRoute"
 import BottomNav from "@/components/BottomNav"
@@ -13,6 +13,7 @@ const Players = lazy(() => import("@/pages/Players"))
 const Tactics = lazy(() => import("@/pages/Tactics"))
 const Profile = lazy(() => import("@/pages/Profile"))
 const Stats = lazy(() => import("@/pages/Stats"))
+const NotFound = lazy(() => import("@/pages/NotFound"))
 
 function App() {
   const { isAuthenticated } = useAuth()
@@ -86,7 +87,14 @@ function App() {
               </PrivateRoute>
             }
           />
-          <Route path="*" element={<Navigate to="/login" />} />
+          <Route
+            path="*"
+            element={
+              <Suspense fallback={<Spinner className="mx-auto mt-4 h-6 w-6 text-primary" />}>
+                <NotFound />
+              </Suspense>
+            }
+          />
         </Routes>
         {isAuthenticated && <BottomNav />}
       </BrowserRouter>

--- a/frontend/src/pages/NotFound.test.tsx
+++ b/frontend/src/pages/NotFound.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MemoryRouter } from 'react-router-dom'
+import NotFound from './NotFound'
+
+describe('NotFound page', () => {
+  it('renders message and link', () => {
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>
+    )
+    expect(screen.getByText(/Page not found/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /login/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,12 @@
+import { Link } from "react-router-dom"
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center space-y-4">
+      <h1 className="text-3xl font-bold">Page not found</h1>
+      <Link to="/login" className="text-blue-600 hover:underline">
+        Go to login
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add NotFound page with message and login link
- render NotFound page for unknown routes
- test NotFound component

## Testing
- `npm test --prefix frontend -- --run`

------
https://chatgpt.com/codex/tasks/task_b_6839f725f6ac8330afb6894ccdedeaca