### PR TITLE
Fix .env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ RABBITMQ_PASSWORD=guest
 
 # NestJS (Backend)
 BACKEND_PORT=3000
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
 
 # React (Frontend)
 VITE_API_URL=http://localhost:3000
@@ -24,8 +24,8 @@ VITE_API_URL=http://localhost:3000
 # FastAPI (IA-Service)
 FASTAPI_HOST=0.0.0.0
 FASTAPI_PORT=8000
-MONGO_URL=mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/
-RABBITMQ_URL=amqp://${RABBITMQ_USER}:${RABBITMQ_PASSWORD}@rabbitmq:5672/
+MONGO_URL=mongodb://admin:secret_password@mongo:27017/
+RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
 
 # Deployment (docker-compose.prod.yml)
 REGISTRY_USER=myuser

--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ archivo `.env.example` en la raíz del proyecto. Cópialo a `.env` y ajusta las
 variables según tu entorno.
 
 La conexión a la base de datos se configura mediante la variable
-`DATABASE_URL` incluida en dichos archivos.
+`DATABASE_URL` incluida en dichos archivos. Si modificas `POSTGRES_USER`,
+`POSTGRES_PASSWORD` o `POSTGRES_DB`, recuerda actualizar `DATABASE_URL`
+con la cadena completa, por ejemplo
+`postgresql://<usuario>:<contraseña>@postgres:5432/<base>`.
 
 El frontend utiliza la variable `VITE_API_URL` para apuntar a la URL base del backend.
 Los directorios `backend/` y `frontend/` incluyen Dockerfiles para construir las imágenes de ambos servicios.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
 BACKEND_PORT=3000
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
 JWT_SECRET=supersecret
 IA_SERVICE_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- expand variable references in example environment files
- note updating `DATABASE_URL` if PostgreSQL creds change

## Testing
- `npm test` in `backend`
- `npm run test -- --run` in `frontend`
- `pytest -q` in `ia-service`


------
https://chatgpt.com/codex/tasks/task_b_683db1a756748330ae49338cd2d286d3