### PR TITLE
Extend player entity fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Gestión de jugadores:
 - Búsqueda de jugadores por nombre
 - Búsqueda de jugadores por posición
 - Nuevo endpoint `/players/position?position=<pos>` para filtrar por posición
-- Campos: id, name, stats (JSONB), fitness, technical
+- Campos: id, name, position, score, stats (JSONB), fitness, technical
 - Validaciones con class-validator
 - Hook usePlayers() en frontend con integración a la API
 - Gestión de formaciones con endpoints protegidos

--- a/backend/src/migrations/1747088295096-CreatePlayersTable.ts
+++ b/backend/src/migrations/1747088295096-CreatePlayersTable.ts
@@ -9,6 +9,9 @@ export class CreatePlayersTable1747088295096 implements MigrationInterface {
             "name" character varying NOT NULL,
             "position" character varying,
             "score" integer NOT NULL DEFAULT 0,
+            "stats" jsonb,
+            "fitness" integer NOT NULL DEFAULT 0,
+            "technical" integer NOT NULL DEFAULT 0,
             CONSTRAINT "PK_players_id" PRIMARY KEY ("id")
         )`);
     }

--- a/backend/src/modules/players/__tests__/players.controller.spec.ts
+++ b/backend/src/modules/players/__tests__/players.controller.spec.ts
@@ -38,7 +38,7 @@ describe('PlayersController', () => {
   });
 
   it('calls service to create a player', () => {
-    controller.create({ name: 'test' } as any);
+    controller.create({ name: 'test', stats: {}, fitness: 10, technical: 20 } as any);
     expect(service.create).toHaveBeenCalled();
   });
 

--- a/backend/src/modules/players/__tests__/players.service.spec.ts
+++ b/backend/src/modules/players/__tests__/players.service.spec.ts
@@ -34,7 +34,12 @@ describe('PlayersService', () => {
   });
 
   it('creates a player', async () => {
-    const data = { name: 'John' } as Partial<Player>;
+    const data = {
+      name: 'John',
+      stats: {},
+      fitness: 50,
+      technical: 60,
+    } as Partial<Player>;
     (repo.create as jest.Mock).mockReturnValue(data);
     (repo.save as jest.Mock).mockResolvedValue({ id: '1', ...data });
 

--- a/backend/src/modules/players/dto/create-player.dto.ts
+++ b/backend/src/modules/players/dto/create-player.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsNumber } from 'class-validator';
+import { IsString, IsOptional, IsNumber, IsObject } from 'class-validator';
 
 export class CreatePlayerDto {
   @IsString()
@@ -11,4 +11,16 @@ export class CreatePlayerDto {
   @IsOptional()
   @IsNumber()
   score?: number;
+
+  @IsOptional()
+  @IsObject()
+  stats?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsNumber()
+  fitness?: number;
+
+  @IsOptional()
+  @IsNumber()
+  technical?: number;
 }

--- a/backend/src/modules/players/dto/update-player.dto.ts
+++ b/backend/src/modules/players/dto/update-player.dto.ts
@@ -1,6 +1,6 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreatePlayerDto } from './create-player.dto';
-import { IsOptional, IsString, IsNumber } from 'class-validator';
+import { IsOptional, IsString, IsNumber, IsObject } from 'class-validator';
 
 export class UpdatePlayerDto extends PartialType(CreatePlayerDto) {
   @IsOptional()
@@ -14,4 +14,16 @@ export class UpdatePlayerDto extends PartialType(CreatePlayerDto) {
   @IsOptional()
   @IsNumber()
   score?: number;
+
+  @IsOptional()
+  @IsNumber()
+  fitness?: number;
+
+  @IsOptional()
+  @IsNumber()
+  technical?: number;
+
+  @IsOptional()
+  @IsObject()
+  stats?: Record<string, unknown>;
 }

--- a/backend/src/modules/players/player.entity.ts
+++ b/backend/src/modules/players/player.entity.ts
@@ -13,5 +13,14 @@ export class Player {
 
   @Column('int', { default: 0 })
   score!: number;
+
+  @Column('jsonb', { nullable: true })
+  stats?: Record<string, unknown>;
+
+  @Column('int', { default: 0 })
+  fitness!: number;
+
+  @Column('int', { default: 0 })
+  technical!: number;
 }
 

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -33,7 +33,7 @@ export class PlayersService {
   }
 
   async update(id: string, data: Partial<Player>): Promise<Player> {
-    await this.playersRepo.update(id, data);
+    await this.playersRepo.update(id, data as any);
     return this.playersRepo.findOneByOrFail({ id });
   }
 

--- a/frontend/src/types/player.ts
+++ b/frontend/src/types/player.ts
@@ -8,6 +8,8 @@ export interface Player {
   position?: string;
   score?: number;
   stats?: PlayerStats;
+  fitness?: number;
+  technical?: number;
 }
 
 export interface CreatePlayerInput {
@@ -15,4 +17,6 @@ export interface CreatePlayerInput {
   position?: string;
   score?: number;
   stats?: PlayerStats;
+  fitness?: number;
+  technical?: number;
 }


### PR DESCRIPTION
## Summary
- update player docs to list all model fields
- include stats, fitness and technical columns on players
- expose new player properties in DTOs and service tests
- update initial migration for new columns
- align frontend `Player` type with backend schema

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683db1ab44408330bb1f3ee74c252849