### PR TITLE
Add stats module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { RatingsModule } from "./modules/ratings/ratings.module";
 import { FormationsModule } from "./modules/formations/formations.module";
 import { IaModule } from "./modules/ia/ia.module";
 import { HealthModule } from "./modules/health/health.module";
+import { StatsModule } from "./modules/stats/stats.module";
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { HealthModule } from "./modules/health/health.module";
     FormationsModule,
     IaModule,
     HealthModule,
+    StatsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/stats/__tests__/stats.controller.spec.ts
+++ b/backend/src/modules/stats/__tests__/stats.controller.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatsController } from '../stats.controller';
+import { StatsService } from '../stats.service';
+
+describe('StatsController', () => {
+  let controller: StatsController;
+  let service: StatsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StatsController],
+      providers: [
+        {
+          provide: StatsService,
+          useValue: { getStats: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<StatsController>(StatsController);
+    service = module.get<StatsService>(StatsService);
+  });
+
+  it('calls service to get stats', async () => {
+    (service.getStats as jest.Mock).mockResolvedValue([{ name: 'A', value: 1 }]);
+
+    const result = await controller.getStats('month');
+
+    expect(service.getStats).toHaveBeenCalledWith('month');
+    expect(result).toEqual([{ name: 'A', value: 1 }]);
+  });
+});

--- a/backend/src/modules/stats/__tests__/stats.service.spec.ts
+++ b/backend/src/modules/stats/__tests__/stats.service.spec.ts
@@ -1,0 +1,41 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PlayersService } from '../../players/players.service';
+import { RatingsService } from '../../ratings/ratings.service';
+import { StatsService } from '../stats.service';
+
+describe('StatsService', () => {
+  let service: StatsService;
+  let playersService: PlayersService;
+  let ratingsService: RatingsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StatsService,
+        { provide: PlayersService, useValue: { findAll: jest.fn() } },
+        { provide: RatingsService, useValue: { averageForPlayer: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<StatsService>(StatsService);
+    playersService = module.get<PlayersService>(PlayersService);
+    ratingsService = module.get<RatingsService>(RatingsService);
+  });
+
+  it('aggregates ratings per player', async () => {
+    (playersService.findAll as jest.Mock).mockResolvedValue([
+      { id: 'p1', name: 'John' },
+      { id: 'p2', name: 'Jane' },
+    ]);
+    (ratingsService.averageForPlayer as jest.Mock)
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(7);
+
+    const result = await service.getStats('month');
+
+    expect(result).toEqual([
+      { name: 'John', value: 5 },
+      { name: 'Jane', value: 7 },
+    ]);
+  });
+});

--- a/backend/src/modules/stats/stats.controller.ts
+++ b/backend/src/modules/stats/stats.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { StatsService } from './stats.service';
+
+@Controller('stats')
+export class StatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  getStats(@Query('range') range: 'month' | 'season' = 'month') {
+    return this.statsService.getStats(range);
+  }
+}

--- a/backend/src/modules/stats/stats.module.ts
+++ b/backend/src/modules/stats/stats.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PlayersModule } from '../players/players.module';
+import { RatingsModule } from '../ratings/ratings.module';
+import { StatsController } from './stats.controller';
+import { StatsService } from './stats.service';
+
+@Module({
+  imports: [PlayersModule, RatingsModule],
+  controllers: [StatsController],
+  providers: [StatsService],
+})
+export class StatsModule {}

--- a/backend/src/modules/stats/stats.service.ts
+++ b/backend/src/modules/stats/stats.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PlayersService } from '../players/players.service';
+import { RatingsService } from '../ratings/ratings.service';
+
+export interface StatItem {
+  name: string;
+  value: number;
+}
+
+@Injectable()
+export class StatsService {
+  constructor(
+    private playersService: PlayersService,
+    private ratingsService: RatingsService,
+  ) {}
+
+  async getStats(range: 'month' | 'season'): Promise<StatItem[]> {
+    const players = await this.playersService.findAll();
+    const result: StatItem[] = [];
+    for (const player of players) {
+      const avg = await this.ratingsService.averageForPlayer(player.id);
+      result.push({ name: player.name, value: avg });
+    }
+    return result;
+  }
+}

--- a/infra/swagger.yaml
+++ b/infra/swagger.yaml
@@ -69,6 +69,24 @@ paths:
       responses:
         '201':
           description: Rating created
+  /stats:
+    get:
+      summary: Get aggregated statistics
+      parameters:
+        - in: query
+          name: range
+          schema:
+            type: string
+            enum: [month, season]
+      responses:
+        '200':
+          description: Stats list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StatItem'
 components:
   schemas:
     LineupRequest:
@@ -135,3 +153,13 @@ components:
       properties:
         prediction:
           type: string
+    StatItem:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: number
+      required:
+        - name
+        - value


### PR DESCRIPTION
## Summary
- implement StatsModule with service and controller
- register module in app.module
- expose `/stats` API endpoint with Swagger docs
- add unit tests for controller and service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dbe43a110833086df2b02c7197895