### PR TITLE
Add DTOs for login/register with tests

### DIFF
--- a/backend/src/modules/auth/__tests__/auth.controller.spec.ts
+++ b/backend/src/modules/auth/__tests__/auth.controller.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe, HttpStatus } from '@nestjs/common';
+import request from 'supertest';
+import { AuthController } from '../auth.controller';
+import { AuthService } from '../auth.service';
+
+describe('AuthController validation', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: { register: jest.fn(), login: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 400 when login body is invalid', () => {
+    return request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'invalid' })
+      .expect(HttpStatus.BAD_REQUEST);
+  });
+
+  it('returns 400 when register body is missing fields', () => {
+    return request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email: 'user@test.com' })
+      .expect(HttpStatus.BAD_REQUEST);
+  });
+});

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,21 +1,23 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
 
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('register')
-  async register(
-    @Body() body: { name: string; email: string; password: string },
-  ) {
-    return this.authService.register(body.name, body.email, body.password);
+  async register(@Body() registerDto: RegisterDto) {
+    return this.authService.register(
+      registerDto.name,
+      registerDto.email,
+      registerDto.password,
+    );
   }
 
   @Post('login')
-  async login(
-    @Body() body: { email: string; password: string },
-  ) {
-    return this.authService.login(body.email, body.password);
+  async login(@Body() loginDto: LoginDto) {
+    return this.authService.login(loginDto.email, loginDto.password);
   }
 }

--- a/backend/src/modules/auth/dto/login.dto.ts
+++ b/backend/src/modules/auth/dto/login.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  password!: string;
+}

--- a/backend/src/modules/auth/dto/register.dto.ts
+++ b/backend/src/modules/auth/dto/register.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class RegisterDto {
+  @IsString()
+  name!: string;
+
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  password!: string;
+}


### PR DESCRIPTION
## Summary
- add `LoginDto` and `RegisterDto`
- use DTOs in `AuthController`
- test auth controller validation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683dbe4585f08330b30973151a117972