### PR TITLE
Handle unauthorized redirect with navigate

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import { lazy, Suspense } from 'react';
 import PrivateRoute from '@/components/PrivateRoute';
 import BottomNav from '@/components/BottomNav';
@@ -19,8 +19,7 @@ function App() {
   const { isAuthenticated } = useAuth();
   return (
     <>
-      <BrowserRouter>
-        <Routes>
+      <Routes>
           <Route
             path="/login"
             element={
@@ -129,8 +128,7 @@ function App() {
           />
         </Routes>
         {isAuthenticated && <BottomNav />}
-      </BrowserRouter>
-      <Toaster />
+        <Toaster />
     </>
   );
 }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import api, { setAuthToken } from '@/services/api';
 
 interface AuthContextType {
@@ -14,6 +15,7 @@ export const AuthContext = createContext<AuthContextType | undefined>(
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const stored = localStorage.getItem('token');
@@ -35,10 +37,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
-    const handler = () => logout();
+    const handler = () => {
+      logout();
+      navigate('/login');
+    };
     window.addEventListener('unauthorized', handler);
     return () => window.removeEventListener('unauthorized', handler);
-  }, [logout]);
+  }, [logout, navigate]);
 
   return (
     <AuthContext.Provider

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,17 +2,20 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './queryClient';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </AuthProvider>
+    </BrowserRouter>
   </StrictMode>,
 );
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -24,9 +24,7 @@ api.interceptors.response.use(
   (res) => res,
   (error) => {
     if (error.response?.status === 401) {
-      setAuthToken(null);
       window.dispatchEvent(new Event('unauthorized'));
-      window.location.href = '/login';
     }
     return Promise.reject(error);
   },


### PR DESCRIPTION
## Summary
- remove redirect logic from axios interceptor
- listen for `unauthorized` events in `AuthProvider` and navigate to `/login`
- wrap providers in `BrowserRouter`
- adjust `App.tsx` to rely on surrounding router

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683dbe499d4c83308d75380c1b0a03a8