### PR TITLE
Replace npm install with npm ci

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Instalo todas las dependencias sin chequear peer-deps
-RUN npm install --legacy-peer-deps
+RUN npm ci --legacy-peer-deps
 
 # Copio el resto del código y compilo
 COPY . .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- use `npm ci` in backend Docker build stage for deterministic install
- use `npm ci` in frontend Dockerfile

## Testing
- `docker build -t sandei-backend-test ./backend` *(fails: `docker: command not found`)*
- `docker build -t sandei-frontend-test ./frontend` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683de8c4e5c883308600b7ef59245b90