### PR TITLE
Add dockerignore files

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,21 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+*.log
+
+# Build output
+dist/
+
+# Tests and coverage
+tests
+coverage
+
+# Environment files
+.env
+.env.*
+*.local
+
+# IDE and others
+.vscode
+.idea
+*.tsbuildinfo

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,21 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+*.log
+
+# Build outputs
+dist/
+dist-ssr/
+
+# Tests and coverage
+tests
+coverage
+
+# Environment files
+.env
+.env.*
+*.local
+
+# IDE and others
+.vscode
+.idea

--- a/ia-service/.dockerignore
+++ b/ia-service/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+*.log
+
+# Virtual environments
+venv/
+.env
+.env.*
+*.local
+
+# Tests
+tests/
+
+# Others
+Dockerfile


### PR DESCRIPTION
## Summary
- create dockerignore files for backend, frontend and ia-service

## Testing
- `docker build -t test-backend .` *(fails: `docker: command not found`)*
- `docker build -t test-frontend .` *(fails: `docker: command not found`)*
- `docker build -t test-ia-service .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683de8c0493883308237b3533ab13366