### PR TITLE
Add tests for missing OPENAI key

### DIFF
--- a/ia-service/tests/test_no_api_key.py
+++ b/ia-service/tests/test_no_api_key.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+import asyncio
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from fastapi import HTTPException
+
+class DummyAsyncClient:
+    async def post(self, *args, **kwargs):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+        return Resp()
+
+sys.modules['httpx'] = types.SimpleNamespace(AsyncClient=DummyAsyncClient)
+
+from app.main import (
+    analyze_performance,
+    predict_match,
+    detect_errors,
+    suggest_tactics,
+    suggest_lineup,
+    PerformanceRequest,
+    MatchPredictionRequest,
+    ErrorDetectionRequest,
+    TacticsRequest,
+    LineupRequest,
+)
+
+
+def test_analyze_performance_no_key(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', None)
+    payload = PerformanceRequest(ratings=[{"player": "John", "score": 7}])
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(analyze_performance(payload, DummyAsyncClient()))
+    assert exc.value.status_code == 500
+
+def test_predict_match_no_key(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', None)
+    payload = MatchPredictionRequest(home_team=['A'], away_team=['B'])
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(predict_match(payload, DummyAsyncClient()))
+    assert exc.value.status_code == 500
+
+def test_detect_errors_no_key(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', None)
+    payload = ErrorDetectionRequest(lineup=['A', 'B'], formation=None)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(detect_errors(payload, DummyAsyncClient()))
+    assert exc.value.status_code == 500
+
+def test_suggest_lineup_no_key(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', None)
+    payload = LineupRequest(players=['A', 'B'], formation='4-4-2')
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(suggest_lineup(payload, DummyAsyncClient()))
+    assert exc.value.status_code == 500
+
+def test_suggest_tactics_no_key(monkeypatch):
+    monkeypatch.setattr('app.main.OPENAI_API_KEY', None)
+    payload = TacticsRequest(players=['John'], style=None)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(suggest_tactics(payload, DummyAsyncClient()))
+    assert exc.value.status_code == 500


### PR DESCRIPTION
## Summary
- cover each IA endpoint when `OPENAI_API_KEY` is unset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683df17a0ef08330a99ab13feb87b021