### PR TITLE
Enable CORS in IA service

### DIFF
--- a/ia-service/README.md
+++ b/ia-service/README.md
@@ -38,6 +38,14 @@ FASTAPI_HOST=0.0.0.0 FASTAPI_PORT=8000 OPENAI_API_KEY=<clave> \
   docker run -p 8000:8000 ia-service
 ```
 
+### CORS
+
+El servicio habilita CORS para permitir peticiones desde el frontend y el backend.
+Actualmente los orígenes permitidos son:
+
+- `http://localhost:5173` (frontend en desarrollo)
+- `http://localhost:3000` (backend NestJS)
+
 ### Endpoints principales
 
 - `GET /` &ndash; comprobación básica del servicio.

--- a/ia-service/app/main.py
+++ b/ia-service/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException, status, Depends
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Optional
 import os
@@ -37,6 +38,20 @@ async def get_http_client() -> httpx.AsyncClient:
     return client
 
 app = FastAPI()
+
+# Allow CORS from the frontend and backend services
+ALLOWED_ORIGINS = [
+    "http://localhost:5173",  # frontend
+    "http://localhost:3000",  # backend
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.on_event("startup")
 async def startup() -> None:

--- a/ia-service/tests/test_cors.py
+++ b/ia-service/tests/test_cors.py
@@ -1,0 +1,34 @@
+import asyncio
+from app.main import app
+
+
+async def call_app(origin: str):
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "headers": [(b"origin", origin.encode()), (b"host", b"testserver")],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+        "scheme": "http",
+        "http_version": "1.1",
+    }
+    messages = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+    return messages
+
+
+def test_cors_headers():
+    messages = asyncio.run(call_app("http://localhost:5173"))
+    start = next(m for m in messages if m["type"] == "http.response.start")
+    headers = dict(start["headers"])
+    assert headers[b"access-control-allow-origin"] == b"http://localhost:5173"


### PR DESCRIPTION
## Summary
- allow CORS requests from frontend and backend
- document allowed CORS origins
- test CORS headers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683df17b46f88330a24cc2ddb1e10361