### PR TITLE
Implement stats range filtering

### DIFF
--- a/backend/src/modules/stats/__tests__/stats.controller.spec.ts
+++ b/backend/src/modules/stats/__tests__/stats.controller.spec.ts
@@ -21,12 +21,21 @@ describe('StatsController', () => {
     service = module.get<StatsService>(StatsService);
   });
 
-  it('calls service to get stats', async () => {
+  it('calls service to get monthly stats', async () => {
     (service.getStats as jest.Mock).mockResolvedValue([{ name: 'A', value: 1 }]);
 
     const result = await controller.getStats('month');
 
     expect(service.getStats).toHaveBeenCalledWith('month');
+    expect(result).toEqual([{ name: 'A', value: 1 }]);
+  });
+
+  it('calls service to get season stats', async () => {
+    (service.getStats as jest.Mock).mockResolvedValue([{ name: 'A', value: 1 }]);
+
+    const result = await controller.getStats('season');
+
+    expect(service.getStats).toHaveBeenCalledWith('season');
     expect(result).toEqual([{ name: 'A', value: 1 }]);
   });
 });

--- a/backend/src/modules/stats/__tests__/stats.service.spec.ts
+++ b/backend/src/modules/stats/__tests__/stats.service.spec.ts
@@ -52,4 +52,28 @@ describe('StatsService', () => {
       { name: 'Jane', value: 7 },
     ]);
   });
+
+  it('passes a date when range is month', async () => {
+    (playersService.findAll as jest.Mock).mockResolvedValue([
+      { id: 'p1', name: 'John' },
+    ]);
+    (ratingsService.averageForPlayer as jest.Mock).mockResolvedValue(5);
+
+    await service.getStats('month');
+
+    const callArgs = (ratingsService.averageForPlayer as jest.Mock).mock.calls[0];
+    expect(callArgs[1]).toBeInstanceOf(Date);
+  });
+
+  it('passes undefined when range is season', async () => {
+    (playersService.findAll as jest.Mock).mockResolvedValue([
+      { id: 'p1', name: 'John' },
+    ]);
+    (ratingsService.averageForPlayer as jest.Mock).mockResolvedValue(5);
+
+    await service.getStats('season');
+
+    const callArgs = (ratingsService.averageForPlayer as jest.Mock).mock.calls[0];
+    expect(callArgs[1]).toBeUndefined();
+  });
 });

--- a/backend/src/modules/stats/stats.service.ts
+++ b/backend/src/modules/stats/stats.service.ts
@@ -16,9 +16,15 @@ export class StatsService {
 
   async getStats(range: 'month' | 'season'): Promise<StatItem[]> {
     const players = await this.playersService.findAll();
+    const since =
+      range === 'month'
+        ? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+        : undefined;
+
     const avgPromises = players.map(player =>
-      this.ratingsService.averageForPlayer(player.id),
+      this.ratingsService.averageForPlayer(player.id, since),
     );
+
     const averages = await Promise.all(avgPromises);
     return players.map((player, index) => ({
       name: player.name,


### PR DESCRIPTION
## Summary
- filter stats by last month or full season
- expand `averageForPlayer` to accept an optional date
- cover range filtering in stats service and controller tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683df17c158083308789a130c015bcf8