### PR TITLE
Improve TacticsBoard input accessibility

### DIFF
--- a/frontend/src/components/TacticsBoard.tsx
+++ b/frontend/src/components/TacticsBoard.tsx
@@ -91,6 +91,7 @@ export default function TacticsBoard() {
                     defaultValue={p.x.toFixed(1)}
                     step="1"
                     className="border px-1 w-16 text-sm"
+                    aria-label="X coordinate"
                   />
                   <input
                     name="y"
@@ -98,6 +99,7 @@ export default function TacticsBoard() {
                     defaultValue={p.y.toFixed(1)}
                     step="1"
                     className="border px-1 w-16 text-sm"
+                    aria-label="Y coordinate"
                   />
                   <button className="bg-blue-700 text-white px-2 rounded text-sm">
                     OK


### PR DESCRIPTION
## Summary
- add aria-labels for X and Y coordinate inputs

## Testing
- `npm run lint` *(fails: 'Spinner' is defined but never used)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683edb06d1748330bf148951da86d65e