### PR TITLE
Improve PlayerQuickInfo accessibility

### DIFF
--- a/frontend/src/components/PlayerQuickInfo.test.tsx
+++ b/frontend/src/components/PlayerQuickInfo.test.tsx
@@ -17,4 +17,21 @@ describe('PlayerQuickInfo', () => {
     fireEvent.click(screen.getByText(/Notas/i));
     expect(screen.getByText(/Notas no disponibles/i)).toBeInTheDocument();
   });
+
+  it('supports keyboard navigation', () => {
+    render(<PlayerQuickInfo player={player} />);
+
+    const tabs = screen.getAllByRole('tab');
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+
+    tabs[0].focus();
+    fireEvent.keyDown(tabs[0], { key: 'ArrowRight' });
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText(/Historial no disponible/i)).toBeInTheDocument();
+
+    fireEvent.keyDown(tabs[1], { key: 'ArrowLeft' });
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+  });
 });

--- a/frontend/src/components/PlayerQuickInfo.tsx
+++ b/frontend/src/components/PlayerQuickInfo.tsx
@@ -1,35 +1,66 @@
 import { Player } from '@/types/player';
-import { useState } from 'react';
+import { useRef, useState, type KeyboardEvent } from 'react';
 
 interface PlayerQuickInfoProps {
   player: Player;
 }
 
 export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
-  const [tab, setTab] = useState<'stats' | 'history' | 'notes'>('stats');
+  const tabs = [
+    { key: 'stats', label: 'Estadísticas' },
+    { key: 'history', label: 'Historial' },
+    { key: 'notes', label: 'Notas' },
+  ] as const;
+  type TabKey = (typeof tabs)[number]['key'];
+
+  const [tab, setTab] = useState<TabKey>('stats');
+  const tabRefs = useRef<HTMLButtonElement[]>([]);
+
+  const focusTab = (index: number) => {
+    const btn = tabRefs.current[index];
+    btn?.focus();
+  };
+
+  const handleKeyDown = (
+    e: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = (index + 1) % tabs.length;
+      setTab(tabs[next].key);
+      focusTab(next);
+    }
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = (index - 1 + tabs.length) % tabs.length;
+      setTab(tabs[prev].key);
+      focusTab(prev);
+    }
+  };
 
   return (
     <div className="bg-white p-4 rounded shadow w-80">
       <h3 className="text-lg font-bold mb-2">{player.name}</h3>
-      <div className="flex gap-2 mb-2">
-        <button
-          className={`px-2 py-1 rounded ${tab === 'stats' ? 'bg-blue-700 text-white' : 'bg-gray-200'}`}
-          onClick={() => setTab('stats')}
-        >
-          Estadísticas
-        </button>
-        <button
-          className={`px-2 py-1 rounded ${tab === 'history' ? 'bg-blue-700 text-white' : 'bg-gray-200'}`}
-          onClick={() => setTab('history')}
-        >
-          Historial
-        </button>
-        <button
-          className={`px-2 py-1 rounded ${tab === 'notes' ? 'bg-blue-700 text-white' : 'bg-gray-200'}`}
-          onClick={() => setTab('notes')}
-        >
-          Notas
-        </button>
+      <div role="tablist" className="flex gap-2 mb-2">
+        {tabs.map((t, idx) => (
+          <button
+            key={t.key}
+            ref={(el) => {
+              if (el) tabRefs.current[idx] = el;
+            }}
+            role="tab"
+            aria-selected={tab === t.key}
+            tabIndex={tab === t.key ? 0 : -1}
+            className={`px-2 py-1 rounded ${
+              tab === t.key ? 'bg-blue-700 text-white' : 'bg-gray-200'
+            }`}
+            onClick={() => setTab(t.key)}
+            onKeyDown={(e) => handleKeyDown(e, idx)}
+          >
+            {t.label}
+          </button>
+        ))}
       </div>
       {tab === 'stats' && (
         <pre className="whitespace-pre-wrap break-all text-sm">


### PR DESCRIPTION
## Summary
- convert quick info buttons into proper tablist
- support keyboard navigation between tabs
- test new tab behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683edb0901f4833094fefd21d09d9f0a