### PR TITLE
Add configurable CORS origins

### DIFF
--- a/ia-service/.env.example
+++ b/ia-service/.env.example
@@ -1,3 +1,4 @@
 FASTAPI_HOST=0.0.0.0
 FASTAPI_PORT=8000
 OPENAI_API_KEY=sk-xxx
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/ia-service/README.md
+++ b/ia-service/README.md
@@ -9,6 +9,7 @@ Copia `.env.example` a `.env` y completa los siguientes valores:
 - `OPENAI_API_KEY` &ndash; clave para autenticarte en la API de OpenAI.
 - `FASTAPI_HOST` &ndash; interfaz donde se iniciará Uvicorn (por defecto `0.0.0.0`).
 - `FASTAPI_PORT` &ndash; puerto de escucha (por defecto `8000`).
+- `ALLOWED_ORIGINS` &ndash; lista de orígenes permitidos (separados por comas) para CORS.
 
 Estas variables son requeridas tanto al ejecutar en local como con Docker.
 

--- a/ia-service/app/main.py
+++ b/ia-service/app/main.py
@@ -39,11 +39,17 @@ async def get_http_client() -> httpx.AsyncClient:
 
 app = FastAPI()
 
-# Allow CORS from the frontend and backend services
-ALLOWED_ORIGINS = [
-    "http://localhost:5173",  # frontend
-    "http://localhost:3000",  # backend
-]
+# Allow CORS from the frontend and backend services. Origins can be overridden
+# via the `ALLOWED_ORIGINS` environment variable, which should contain a
+# comma-separated list of URLs.
+_origins_env = os.getenv("ALLOWED_ORIGINS")
+if _origins_env:
+    ALLOWED_ORIGINS = [o.strip() for o in _origins_env.split(",") if o.strip()]
+else:
+    ALLOWED_ORIGINS = [
+        "http://localhost:5173",  # frontend
+        "http://localhost:3000",  # backend
+    ]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- add `ALLOWED_ORIGINS` example variable
- read `ALLOWED_ORIGINS` from environment in FastAPI app
- document new variable in IA service README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f20bf728c8330ab3fb86ef92e5a1e