### PR TITLE
Add DB_LOGGING env option

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,4 @@ BACKEND_PORT=3000
 DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
 JWT_SECRET=supersecret
 IA_SERVICE_URL=http://localhost:8000
+DB_LOGGING=true

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -15,4 +15,5 @@ export const env = {
   databaseUrl: requireEnv('DATABASE_URL'),
   jwtSecret: requireEnv('JWT_SECRET'),
   iaServiceUrl: requireEnv('IA_SERVICE_URL'),
+  dbLogging: process.env.DB_LOGGING === 'true',
 };

--- a/backend/src/data-source.ts
+++ b/backend/src/data-source.ts
@@ -7,6 +7,6 @@ export const AppDataSource = new DataSource({
   entities: [__dirname + '/**/*.entity{.ts,.js}'],
   migrations: [__dirname + '/migrations/*{.ts,.js}'],
   synchronize: false,
-  logging: true,
+  logging: env.dbLogging,
 });
 


### PR DESCRIPTION
## Summary
- add `DB_LOGGING` example value to backend environment template
- read new variable in env config
- use `dbLogging` option when creating the `DataSource`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683f20bf956c83309662ca2304e21314