### PR TITLE
Improve frontend aesthetics

### DIFF
--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -12,7 +12,7 @@ export default function BottomNav() {
   return (
     <nav
       aria-label="Menú de navegación"
-      className="fixed bottom-0 left-0 right-0 bg-white border-t flex justify-around py-2 text-sm md:hidden"
+      className="fixed bottom-0 left-0 right-0 border-t border-border bg-white/90 dark:bg-slate-800/90 backdrop-blur-md shadow-md flex justify-around py-2 text-sm md:hidden"
     >
       <NavLink
         to="/dashboard"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,7 +140,13 @@ html {
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground font-sans pb-16;
+    @apply text-foreground font-sans pb-16;
+    background-color: var(--color-background);
+    background-image: linear-gradient(
+      to bottom right,
+      var(--color-background),
+      var(--color-muted)
+    );
   }
   h1, h2, h3, .font-display {
     @apply font-display;


### PR DESCRIPTION
## Summary
- soften the background with a gradient
- add blur and softer colors to the bottom navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840649fc1008330b868dc43cdf92cea