### PR TITLE
Add dev and prod env templates

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,36 @@
+# Development environment for SandeiApp
+# Copy this file to .env when running the stack locally.
+# Differences from .env.prod: VITE_API_URL points to localhost services.
+
+# PostgreSQL
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=secret_password
+POSTGRES_DB=sandeidb
+
+# MongoDB
+MONGO_USER=admin
+MONGO_PASSWORD=secret_password
+
+# Redis
+REDIS_PASSWORD=secret_password
+
+# RabbitMQ
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest
+
+# NestJS (Backend)
+BACKEND_PORT=3000
+DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
+
+# React (Frontend)
+VITE_API_URL=http://localhost:3000
+
+# FastAPI (IA-Service)
+FASTAPI_HOST=0.0.0.0
+FASTAPI_PORT=8000
+MONGO_URL=mongodb://admin:secret_password@mongo:27017/
+RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+
+# Deployment (docker-compose.prod.yml)
+REGISTRY_USER=myuser
+TAG=latest

--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,37 @@
+# Production environment for SandeiApp
+# Copy this file to .env for deployments with infra/docker-compose.prod.yml
+# Differences from .env.dev: VITE_API_URL points to the public backend and
+# REGISTRY_USER/TAG select the images to deploy.
+
+# PostgreSQL
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=secret_password
+POSTGRES_DB=sandeidb
+
+# MongoDB
+MONGO_USER=admin
+MONGO_PASSWORD=secret_password
+
+# Redis
+REDIS_PASSWORD=secret_password
+
+# RabbitMQ
+RABBITMQ_USER=guest
+RABBITMQ_PASSWORD=guest
+
+# NestJS (Backend)
+BACKEND_PORT=3000
+DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
+
+# React (Frontend)
+VITE_API_URL=https://api.example.com
+
+# FastAPI (IA-Service)
+FASTAPI_HOST=0.0.0.0
+FASTAPI_PORT=8000
+MONGO_URL=mongodb://admin:secret_password@mongo:27017/
+RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+
+# Deployment
+REGISTRY_USER=myuser
+TAG=latest

--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -1,0 +1,7 @@
+# Development environment for the backend
+# Differences from .env.prod: IA_SERVICE_URL uses localhost and DB_LOGGING is true
+BACKEND_PORT=3000
+DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
+JWT_SECRET=supersecret
+IA_SERVICE_URL=http://localhost:8000
+DB_LOGGING=true

--- a/backend/.env.prod
+++ b/backend/.env.prod
@@ -1,0 +1,8 @@
+# Production environment for the backend
+# Differences from .env.dev: IA_SERVICE_URL uses the internal service hostname
+# and DB_LOGGING is disabled.
+BACKEND_PORT=3000
+DATABASE_URL=postgresql://postgres:secret_password@postgres:5432/sandeidb
+JWT_SECRET=supersecret
+IA_SERVICE_URL=http://ia-service:8000
+DB_LOGGING=false

--- a/frontend/.env.dev
+++ b/frontend/.env.dev
@@ -1,0 +1,3 @@
+# Development environment for the frontend
+# Differences from .env.prod: VITE_API_URL points to the local backend
+VITE_API_URL=http://localhost:3000

--- a/frontend/.env.prod
+++ b/frontend/.env.prod
@@ -1,0 +1,3 @@
+# Production environment for the frontend
+# Differences from .env.dev: VITE_API_URL should point to your deployed backend
+VITE_API_URL=https://api.example.com

--- a/ia-service/.env.dev
+++ b/ia-service/.env.dev
@@ -1,0 +1,6 @@
+# Development environment for the IA service
+# Differences from .env.prod: ALLOWED_ORIGINS includes localhost URLs
+FASTAPI_HOST=0.0.0.0
+FASTAPI_PORT=8000
+OPENAI_API_KEY=sk-xxx
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/ia-service/.env.prod
+++ b/ia-service/.env.prod
@@ -1,0 +1,6 @@
+# Production environment for the IA service
+# Differences from .env.dev: ALLOWED_ORIGINS should contain your frontend domain
+FASTAPI_HOST=0.0.0.0
+FASTAPI_PORT=8000
+OPENAI_API_KEY=sk-xxx
+ALLOWED_ORIGINS=https://example.com

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,23 @@
+# Scripts
+
+This folder contains helper scripts for running the project. The main entry point
+is `run_local.sh` located in the repository root.
+
+## Choosing an environment file
+
+`run_local.sh` expects a `.env` file in the project root. Copy the template that
+matches your environment before executing the script:
+
+```bash
+# For development
+cp .env.dev .env
+./run_local.sh
+
+# For production
+cp .env.prod .env
+./run_local.sh
+```
+
+Each service directory (`backend/`, `frontend/` and `ia-service/`) also provides
+`.env.dev` and `.env.prod` templates. Copy the appropriate file to `.env` inside
+that directory before building or running the container.


### PR DESCRIPTION
## Summary
- add development and production `.env` templates to root and services
- document how to choose the right file in `scripts/README.md`

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`
- `pytest -q` in `ia-service`


------
https://chatgpt.com/codex/tasks/task_b_68408b3ca72883309f17efed44073a98