### PR TITLE
Fix Dockerfile install command

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Instalo todas las dependencias sin chequear peer-deps
-RUN npm ci --legacy-peer-deps
+RUN npm install --legacy-peer-deps
 
 # Copio el resto del código y compilo
 COPY . .


### PR DESCRIPTION
## Summary
- use `npm install --legacy-peer-deps` instead of `npm ci`

## Testing
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684303da11508330b6585e73a86cc399