### PR TITLE
Enhanced frontend with demo data and sharing features

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { FormationsModule } from "./modules/formations/formations.module";
 import { IaModule } from "./modules/ia/ia.module";
 import { HealthModule } from "./modules/health/health.module";
 import { StatsModule } from "./modules/stats/stats.module";
+import { DemoModule } from "./modules/demo/demo.module";
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { StatsModule } from "./modules/stats/stats.module";
     IaModule,
     HealthModule,
     StatsModule,
+    DemoModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/modules/demo/demo.controller.ts
+++ b/backend/src/modules/demo/demo.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Post, UseGuards } from '@nestjs/common';
+import { DemoService } from './demo.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('demo')
+export class DemoController {
+  constructor(private readonly demo: DemoService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  createDemo() {
+    return this.demo.createDemoData();
+  }
+}

--- a/backend/src/modules/demo/demo.module.ts
+++ b/backend/src/modules/demo/demo.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PlayersModule } from '../players/players.module';
+import { MatchesModule } from '../matches/matches.module';
+import { RatingsModule } from '../ratings/ratings.module';
+import { DemoController } from './demo.controller';
+import { DemoService } from './demo.service';
+
+@Module({
+  imports: [PlayersModule, MatchesModule, RatingsModule],
+  controllers: [DemoController],
+  providers: [DemoService],
+})
+export class DemoModule {}

--- a/backend/src/modules/demo/demo.service.ts
+++ b/backend/src/modules/demo/demo.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { PlayersService } from '../players/players.service';
+import { MatchesService } from '../matches/matches.service';
+import { RatingsService } from '../ratings/ratings.service';
+
+@Injectable()
+export class DemoService {
+  constructor(
+    private players: PlayersService,
+    private matches: MatchesService,
+    private ratings: RatingsService,
+  ) {}
+
+  async createDemoData() {
+    const playerPromises = Array.from({ length: 11 }).map((_, i) =>
+      this.players.create({
+        name: `Demo ${i + 1}`,
+        position: 'N/A',
+        score: Math.floor(Math.random() * 10),
+        technical: Math.floor(Math.random() * 10),
+        fitness: Math.floor(Math.random() * 10),
+      }),
+    );
+    const players = await Promise.all(playerPromises);
+
+    const match1 = await this.matches.create({ date: new Date() });
+    const match2 = await this.matches.create({
+      date: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    });
+
+    for (const match of [match1, match2]) {
+      for (const player of players) {
+        await this.ratings.create(match.id, player.id, Math.floor(Math.random() * 10));
+      }
+    }
+    return { players, matches: [match1, match2] };
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,11 @@
     "react-router-dom": "^6.30.0",
     "recharts": "^2.9.0",
     "sonner": "^2.0.3",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1",
+    "react-csv": "^2.2.2",
+    "react-joyride": "^2.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import type { Step } from 'react-joyride';
+
+let Joyride: any;
+
+const steps: Step[] = [
+  {
+    target: '#add-player',
+    content: 'Crea tu primer jugador aquí',
+  },
+  {
+    target: '#add-formation',
+    content: 'Diseña la formación táctica',
+  },
+  {
+    target: '#stats-link',
+    content: 'Consulta las estadísticas de rendimiento',
+  },
+];
+
+export default function Onboarding() {
+  const [run, setRun] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    import('react-joyride').then((mod) => {
+      Joyride = mod.default;
+      setLoaded(true);
+    });
+    const done = localStorage.getItem('tourDone');
+    if (!done) setRun(true);
+  }, []);
+
+  return (
+    loaded && (
+      <Joyride
+        steps={steps}
+        run={run}
+        continuous
+        showSkipButton
+        callback={(data: any) => {
+          if (data.status === 'finished' || data.status === 'skipped') {
+            localStorage.setItem('tourDone', 'true');
+          }
+        }}
+      />
+    )
+  );
+}

--- a/frontend/src/components/PlayerQuickInfo.tsx
+++ b/frontend/src/components/PlayerQuickInfo.tsx
@@ -1,5 +1,6 @@
 import { Player } from '@/types/player';
 import { useRef, useState, type KeyboardEvent } from 'react';
+import { ExportPlayerPDF } from './exports/ExportButtons';
 
 interface PlayerQuickInfoProps {
   player: Player;
@@ -75,6 +76,9 @@ export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
       {tab === 'notes' && (
         <p className="text-sm text-gray-600">Notas no disponibles.</p>
       )}
+      <div className="mt-4 text-right">
+        <ExportPlayerPDF player={player} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/TacticsBoard.tsx
+++ b/frontend/src/components/TacticsBoard.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import html2canvas from 'html2canvas';
 
 interface PlayerPos {
   id: string;
@@ -17,6 +18,7 @@ const initialPlayers: PlayerPos[] = [
 
 export default function TacticsBoard() {
   const [players, setPlayers] = useState(initialPlayers);
+  const boardRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState<string | null>(null);
   const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | null>(null);
 
@@ -50,12 +52,21 @@ export default function TacticsBoard() {
     setEditing(null);
   };
 
+  const share = async () => {
+    if (!boardRef.current) return;
+    const canvas = await html2canvas(boardRef.current);
+    const url = canvas.toDataURL();
+    window.open(`https://wa.me/?text=${encodeURIComponent(url)}`, '_blank');
+  };
+
   return (
-    <div
-      className="relative w-full h-96 bg-green-700 rounded"
-      onDragOver={(e) => e.preventDefault()}
-      onDrop={onDrop}
-    >
+    <div className="space-y-2">
+      <div
+        ref={boardRef}
+        className="relative w-full h-96 bg-green-700 rounded"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+      >
       {players.map((p) => (
         <div
           key={p.id}
@@ -110,6 +121,10 @@ export default function TacticsBoard() {
           )}
         </div>
       ))}
+      </div>
+      <button onClick={share} className="bg-blue-700 text-white px-4 py-1 rounded">
+        Compartir por WhatsApp
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/exports/ExportButtons.tsx
+++ b/frontend/src/components/exports/ExportButtons.tsx
@@ -1,0 +1,50 @@
+import { Player } from '@/types/player';
+import { type FC, useState, useEffect } from 'react';
+import { Button } from '../ui/button';
+
+let jsPDF: any;
+let html2canvas: any;
+let CSVLink: any;
+
+export const ExportPlayerPDF: FC<{ player: Player }> = ({ player }) => {
+  const generate = async () => {
+    if (!jsPDF) jsPDF = (await import('jspdf')).default;
+    const doc = new jsPDF();
+    doc.text(`Ficha de ${player.name}`, 10, 10);
+    doc.text(JSON.stringify(player, null, 2), 10, 20);
+    doc.save(`${player.name}.pdf`);
+  };
+  return (
+    <Button onClick={generate} variant="outline">
+      Exportar PDF
+    </Button>
+  );
+};
+
+export const ExportListCSV: FC<{ data: unknown[] }> = ({ data }) => {
+  const [Link, setLink] = useState<typeof CSVLink | null>(CSVLink);
+  useEffect(() => {
+    if (!Link) {
+      import('react-csv').then((mod) => {
+        CSVLink = mod.CSVLink;
+        setLink(mod.CSVLink);
+      });
+    }
+  }, [Link]);
+  if (!Link) return null;
+  return (
+    <Link data={data} filename="reporte.csv" className="inline-block">
+      <Button variant="outline">Exportar CSV</Button>
+    </Link>
+  );
+};
+
+export async function exportElementPDF(element: HTMLElement, filename: string) {
+  if (!html2canvas) html2canvas = (await import('html2canvas')).default;
+  if (!jsPDF) jsPDF = (await import('jspdf')).default;
+  const canvas = await html2canvas(element);
+  const imgData = canvas.toDataURL('image/png');
+  const doc = new jsPDF();
+  doc.addImage(imgData, 'PNG', 0, 0, 200, 0);
+  doc.save(filename);
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import PlayerQuickInfo from '@/components/PlayerQuickInfo';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import Onboarding from '@/components/Onboarding';
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -128,5 +129,6 @@ export default function Dashboard() {
         </Button>
       </div>
     </motion.div>
+    <Onboarding />
   );
 }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,8 +1,54 @@
+import { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
 export default function Profile() {
+  const [name, setName] = useState('');
+  const [color, setColor] = useState('#000000');
+  const [logo, setLogo] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('clubProfile');
+    if (stored) {
+      const data = JSON.parse(stored);
+      setName(data.name || '');
+      setColor(data.color || '#000000');
+      setLogo(data.logo || null);
+    }
+  }, []);
+
+  const save = () => {
+    localStorage.setItem('clubProfile', JSON.stringify({ name, color, logo }));
+  };
+
   return (
-    <div className="p-6">
-      <h2 className="text-xl font-bold">Perfil</h2>
-      <p>A\u00fan no hay contenido.</p>
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-bold">Perfil del Club</h2>
+      <div className="space-y-2">
+        <label className="block text-sm">Nombre</label>
+        <Input value={name} onChange={(e) => setName(e.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <label className="block text-sm">Color principal</label>
+        <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <label className="block text-sm">Logo</label>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) {
+              const reader = new FileReader();
+              reader.onload = () => setLogo(reader.result as string);
+              reader.readAsDataURL(file);
+            }
+          }}
+        />
+        {logo && <img src={logo} alt="logo" className="h-20 w-20 object-contain" />}
+      </div>
+      <Button onClick={save}>Guardar</Button>
     </div>
   );
 }

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -4,6 +4,7 @@ import { register as registerUser } from '@/services/authService';
 import Spinner from '@/components/ui/spinner';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { createDemoData } from '@/services/demo';
 
 export default function Register() {
   const [step, setStep] = useState(1);
@@ -14,6 +15,7 @@ export default function Register() {
   const [role, setRole] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
+  const [demo, setDemo] = useState(false);
   const navigate = useNavigate();
   const totalSteps = 3;
 
@@ -55,6 +57,13 @@ export default function Register() {
     setLoading(true);
     try {
       await registerUser(name, email, password);
+      if (demo) {
+        try {
+          await createDemoData();
+        } catch (err) {
+          console.error('Demo data error', err);
+        }
+      }
       navigate('/login');
     } catch {
       setErrors({ submit: 'No se pudo registrar el usuario' });
@@ -184,6 +193,14 @@ export default function Register() {
           <p>
             <strong>Posición:</strong> {role}
           </p>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={demo}
+              onChange={(e) => setDemo(e.target.checked)}
+            />
+            <span>Probar con equipo de ejemplo</span>
+          </label>
           {errors.submit && (
             <p className="text-red-500 text-sm">{errors.submit}</p>
           )}

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -5,6 +5,8 @@ import {
   PolarAngleAxis,
   PolarRadiusAxis,
   Radar,
+  LineChart,
+  Line,
   BarChart,
   Bar,
   XAxis,
@@ -19,6 +21,7 @@ import Spinner from '@/components/ui/spinner';
 
 export default function Stats() {
   const [range, setRange] = useState<'month' | 'season'>('month');
+  const [selected, setSelected] = useState<string | null>(null);
   const { data, isLoading, error } = useStats(range);
 
   const stats = data || [];
@@ -73,6 +76,27 @@ export default function Stats() {
             fillOpacity={0.6}
           />
         </RadarChart>
+        {selected && (
+          <LineChart width={300} height={200} data={stats}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Line type="monotone" dataKey="value" stroke="#ff7300" />
+          </LineChart>
+        )}
+      </div>
+      <div className="flex gap-2 flex-wrap">
+        {stats.map((s) => (
+          <Button
+            key={s.name}
+            variant={selected === s.name ? 'default' : 'outline'}
+            onClick={() => setSelected(s.name)}
+          >
+            {s.name}
+          </Button>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/services/demo.ts
+++ b/frontend/src/services/demo.ts
@@ -1,0 +1,5 @@
+import api from './api';
+
+export async function createDemoData() {
+  await api.post('/demo');
+}


### PR DESCRIPTION
## Summary
- add DemoModule on backend for quick demo data
- implement onboarding tour and export utilities
- share tactics via WhatsApp with html2canvas
- offer demo data on registration
- support club profile customization and advanced stats

## Testing
- `npm test` *(fails: Failed to resolve import "jspdf")*

------
https://chatgpt.com/codex/tasks/task_b_68430585c0fc8330b98146cfe7c8ed2a