### PR TITLE
Add onboarding seed data and WhatsApp share

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ Frontend:
 cd frontend
 npm run test
 
+Datos de ejemplo:
+
+Para poblar la base con registros de prueba ejecuta:
+
+```bash
+cd backend
+npm run seed
+```
+
 
 ---
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js"
+    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
+    "seed": "ts-node -r tsconfig-paths/register src/scripts/seed.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -1,0 +1,51 @@
+import { AppDataSource } from '../data-source';
+import { Player } from '../modules/players/player.entity';
+import { Formation } from '../modules/formations/formation.entity';
+import { Match } from '../modules/matches/match.entity';
+
+async function seed() {
+  await AppDataSource.initialize();
+
+  const playersRepo = AppDataSource.getRepository(Player);
+  const formationsRepo = AppDataSource.getRepository(Formation);
+  const matchesRepo = AppDataSource.getRepository(Match);
+
+  const players = [
+    { name: 'Juan Pérez', position: 'Delantero', fitness: 80, technical: 85 },
+    { name: 'Carlos Díaz', position: 'Mediocampista', fitness: 75, technical: 80 },
+    { name: 'Luis Gómez', position: 'Defensa', fitness: 85, technical: 70 },
+  ];
+
+  for (const p of players) {
+    await playersRepo.save(playersRepo.create(p));
+  }
+
+  const formations = [
+    {
+      name: '4-4-2 Clásico',
+      description:
+        'Formación básica con 4 defensas, 4 mediocampistas y 2 delanteros.',
+    },
+    {
+      name: '4-3-3 Ofensiva',
+      description: 'Mayor presencia en ataque con tres delanteros.',
+    },
+  ];
+
+  for (const f of formations) {
+    await formationsRepo.save(formationsRepo.create(f));
+  }
+
+  await matchesRepo.save(matchesRepo.create({ date: new Date() }));
+
+  await AppDataSource.destroy();
+}
+
+seed()
+  .then(() => {
+    console.log('Datos de ejemplo cargados.');
+  })
+  .catch(async (err) => {
+    console.error('Error al cargar datos:', err);
+    await AppDataSource.destroy();
+  });

--- a/frontend/src/components/FormationCard.tsx
+++ b/frontend/src/components/FormationCard.tsx
@@ -1,11 +1,15 @@
 import { Formation } from '@/types/formation';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
 interface FormationCardProps {
   formation: Formation;
 }
 
 export default function FormationCard({ formation }: FormationCardProps) {
+  const shareText = `Formación ${formation.name}${
+    formation.description ? ` - ${formation.description}` : ''}`;
+
   return (
     <Card className="flex flex-col gap-2">
       <CardHeader>
@@ -16,6 +20,17 @@ export default function FormationCard({ formation }: FormationCardProps) {
           <p>{formation.description}</p>
         </CardContent>
       )}
+      <CardContent className="flex justify-end pt-0">
+        <Button asChild size="sm" variant="outline">
+          <a
+            href={`https://wa.me/?text=${encodeURIComponent(shareText)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Compartir
+          </a>
+        </Button>
+      </CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- add a small seed script to preload example players, formations and a match
- expose the script via `npm run seed`
- document how to preload example data in the README
- add a WhatsApp share button on each formation card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684305264b10833090163bc9e1bf9cf5