### PR TITLE
Fix dashboard JSX root

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -35,7 +35,8 @@ export default function Dashboard() {
   }
 
   return (
-    <motion.div
+    <>
+      <motion.div
       className="p-6 space-y-4"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -128,7 +129,8 @@ export default function Dashboard() {
           Cerrar sesión
         </Button>
       </div>
-    </motion.div>
-    <Onboarding />
+      </motion.div>
+      <Onboarding />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- fix Dashboard page to return a single fragment wrapper for elements

## Testing
- `npm run build` *(fails: TS errors in other files)*
- `npm test`
- `npm run lint` *(fails: 5 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68431c07192c8330850df42beb16cd99