### PR TITLE
Improve types and error handling in frontend

### DIFF
--- a/frontend/src/components/FormationWizard.tsx
+++ b/frontend/src/components/FormationWizard.tsx
@@ -96,7 +96,7 @@ export default function FormationWizard({
           <span />
         )}
         {step < totalSteps && (
-          <Button variant="primary" onClick={next}>
+          <Button variant="default" onClick={next}>
             Siguiente
           </Button>
         )}

--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect } from 'react';
-import type { Step } from 'react-joyride';
+import type {
+  Step,
+  Props as JoyrideProps,
+  CallBackProps,
+} from 'react-joyride';
+import type { ComponentType } from 'react';
 
-let Joyride: any;
+let Joyride: ComponentType<JoyrideProps> | null = null;
 
 const steps: Step[] = [
   {
@@ -38,7 +43,7 @@ export default function Onboarding() {
         run={run}
         continuous
         showSkipButton
-        callback={(data: any) => {
+        callback={(data: CallBackProps) => {
           if (data.status === 'finished' || data.status === 'skipped') {
             localStorage.setItem('tourDone', 'true');
           }

--- a/frontend/src/components/PlayerWizard.tsx
+++ b/frontend/src/components/PlayerWizard.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import Spinner from '@/components/ui/spinner';
 import { Button } from '@/components/ui/button';
+import type { PlayerStats } from '@/types/player';
 
 export interface PlayerWizardData {
   name: string;
-  stats: Record<string, unknown>;
+  stats: PlayerStats;
 }
 
 export default function PlayerWizard({
@@ -44,7 +45,7 @@ export default function PlayerWizard({
   const finish = async () => {
     try {
       setSaving(true);
-      const parsed = stats ? JSON.parse(stats) : {};
+      const parsed: PlayerStats = stats ? JSON.parse(stats) : {};
       await onComplete({ name, stats: parsed });
     } finally {
       setSaving(false);
@@ -123,7 +124,7 @@ export default function PlayerWizard({
           <span />
         )}
         {step < totalSteps && (
-          <Button variant="primary" onClick={next}>
+          <Button variant="default" onClick={next}>
             Siguiente
           </Button>
         )}

--- a/frontend/src/components/exports/ExportButtons.tsx
+++ b/frontend/src/components/exports/ExportButtons.tsx
@@ -2,9 +2,9 @@ import { Player } from '@/types/player';
 import { type FC, useState, useEffect } from 'react';
 import { Button } from '../ui/button';
 
-let jsPDF: any;
-let html2canvas: any;
-let CSVLink: any;
+let jsPDF: typeof import('jspdf')['default'] | undefined;
+let html2canvasLib: typeof import('html2canvas')['default'] | undefined;
+let CSVLink: typeof import('react-csv').CSVLink | undefined;
 
 export const ExportPlayerPDF: FC<{ player: Player }> = ({ player }) => {
   const generate = async () => {
@@ -22,7 +22,7 @@ export const ExportPlayerPDF: FC<{ player: Player }> = ({ player }) => {
 };
 
 export const ExportListCSV: FC<{ data: unknown[] }> = ({ data }) => {
-  const [Link, setLink] = useState<typeof CSVLink | null>(CSVLink);
+  const [Link, setLink] = useState<typeof CSVLink | null>(CSVLink ?? null);
   useEffect(() => {
     if (!Link) {
       import('react-csv').then((mod) => {
@@ -40,9 +40,9 @@ export const ExportListCSV: FC<{ data: unknown[] }> = ({ data }) => {
 };
 
 export async function exportElementPDF(element: HTMLElement, filename: string) {
-  if (!html2canvas) html2canvas = (await import('html2canvas')).default;
+  if (!html2canvasLib) html2canvasLib = (await import('html2canvas')).default;
   if (!jsPDF) jsPDF = (await import('jspdf')).default;
-  const canvas = await html2canvas(element);
+  const canvas = await html2canvasLib(element);
   const imgData = canvas.toDataURL('image/png');
   const doc = new jsPDF();
   doc.addImage(imgData, 'PNG', 0, 0, 200, 0);

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -38,7 +38,12 @@ export default function Players() {
         </div>
       </div>
     );
-  if (error) return <p className="text-red-500 text-center mt-10">{error}</p>;
+  if (error)
+    return (
+      <p className="text-red-500 text-center mt-10">{String(error)}</p>
+    );
+
+  const playerList = players ?? [];
 
   return (
     <div className="p-6 space-y-4">
@@ -48,14 +53,14 @@ export default function Players() {
         Crear jugador
       </Button>
 
-      {players.length === 0 ? (
+      {playerList.length === 0 ? (
         <div className="text-center py-10 space-y-2">
           <p className="text-gray-500">Aún no hay jugadores.</p>
           <Button onClick={() => setShowModal(true)}>Añadir jugador</Button>
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-          {players.map((player) => (
+          {playerList.map((player) => (
             <PlayerCard
               key={player.id}
               player={player}

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -18,12 +18,12 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 1,
-      onError: (error) => {
+      onError: (error: unknown) => {
         toast.error(getMessage(error));
       },
     },
     mutations: {
-      onError: (error) => {
+      onError: (error: unknown) => {
         toast.error(getMessage(error));
       },
     },

--- a/frontend/src/types/react-csv.d.ts
+++ b/frontend/src/types/react-csv.d.ts
@@ -1,0 +1,11 @@
+declare module 'react-csv' {
+  import { ComponentType } from 'react';
+  export interface CSVLinkProps {
+    data: unknown[];
+    filename?: string;
+    headers?: string[];
+    [key: string]: unknown;
+  }
+  export const CSVLink: ComponentType<CSVLinkProps>;
+  export const CSVDownload: ComponentType<CSVLinkProps>;
+}


### PR DESCRIPTION
## Summary
- refine types for `Onboarding` and `ExportButtons`
- use `PlayerStats` in `PlayerWizard`
- handle undefined players and error display in `Players`
- fix button variants in wizards
- type errors in query client
- declare module for `react-csv`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68433899ab308330a0c3e791a1c894a5