### PR TITLE
Improve React performance

### DIFF
--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom';
+import { memo } from 'react';
 import {
   FaHome,
   FaUserFriends,
@@ -8,7 +9,7 @@ import {
 } from 'react-icons/fa';
 import ThemeToggle from './ThemeToggle';
 
-export default function BottomNav() {
+function BottomNav() {
   return (
     <nav
       aria-label="Menú de navegación"
@@ -59,3 +60,5 @@ export default function BottomNav() {
     </nav>
   );
 }
+
+export default memo(BottomNav);

--- a/frontend/src/components/FormationCard.tsx
+++ b/frontend/src/components/FormationCard.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react';
 import { Formation } from '@/types/formation';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -6,9 +7,15 @@ interface FormationCardProps {
   formation: Formation;
 }
 
-export default function FormationCard({ formation }: FormationCardProps) {
-  const shareText = `Formación ${formation.name}${
-    formation.description ? ` - ${formation.description}` : ''}`;
+function FormationCard({ formation }: FormationCardProps) {
+  // Memoize share text to avoid recalculations on parent rerenders
+  const shareText = useMemo(
+    () =>
+      `Formación ${formation.name}${
+        formation.description ? ` - ${formation.description}` : ''
+      }`,
+    [formation.name, formation.description],
+  );
 
   return (
     <Card className="flex flex-col gap-2">
@@ -34,3 +41,5 @@ export default function FormationCard({ formation }: FormationCardProps) {
     </Card>
   );
 }
+export default memo(FormationCard);
+

--- a/frontend/src/components/PlayerCard.tsx
+++ b/frontend/src/components/PlayerCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Player } from '@/types/player';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -9,7 +10,8 @@ interface PlayerCardProps {
   onDelete?: () => void;
 }
 
-export default function PlayerCard({
+// Wrapped with memo to prevent unnecessary rerenders when props remain stable
+function PlayerCard({
   player,
   onEdit,
   onDelete,
@@ -55,3 +57,5 @@ export default function PlayerCard({
     </motion.div>
   );
 }
+
+export default memo(PlayerCard);

--- a/frontend/src/components/PlayerQuickInfo.tsx
+++ b/frontend/src/components/PlayerQuickInfo.tsx
@@ -1,12 +1,12 @@
+import { memo, useCallback, useRef, useState, type KeyboardEvent } from 'react';
 import { Player } from '@/types/player';
-import { useRef, useState, type KeyboardEvent } from 'react';
 import { ExportPlayerPDF } from './exports/ExportButtons';
 
 interface PlayerQuickInfoProps {
   player: Player;
 }
 
-export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
+function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
   const tabs = [
     { key: 'stats', label: 'Estadísticas' },
     { key: 'history', label: 'Historial' },
@@ -17,28 +17,28 @@ export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
   const [tab, setTab] = useState<TabKey>('stats');
   const tabRefs = useRef<HTMLButtonElement[]>([]);
 
-  const focusTab = (index: number) => {
+  const focusTab = useCallback((index: number) => {
     const btn = tabRefs.current[index];
     btn?.focus();
-  };
+  }, []);
 
-  const handleKeyDown = (
-    e: KeyboardEvent<HTMLButtonElement>,
-    index: number,
-  ) => {
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-      e.preventDefault();
-      const next = (index + 1) % tabs.length;
-      setTab(tabs[next].key);
-      focusTab(next);
-    }
-    if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-      e.preventDefault();
-      const prev = (index - 1 + tabs.length) % tabs.length;
-      setTab(tabs[prev].key);
-      focusTab(prev);
-    }
-  };
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = (index + 1) % tabs.length;
+        setTab(tabs[next].key);
+        focusTab(next);
+      }
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = (index - 1 + tabs.length) % tabs.length;
+        setTab(tabs[prev].key);
+        focusTab(prev);
+      }
+    },
+    [focusTab, tabs],
+  );
 
   return (
     <div className="bg-white p-4 rounded shadow w-80">
@@ -82,3 +82,5 @@ export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
     </div>
   );
 }
+export default memo(PlayerQuickInfo);
+

--- a/frontend/src/components/TacticsBoard.tsx
+++ b/frontend/src/components/TacticsBoard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { memo, useCallback, useRef, useState } from 'react';
 import html2canvas from 'html2canvas';
 
 interface PlayerPos {
@@ -16,48 +16,51 @@ const initialPlayers: PlayerPos[] = [
   { id: '5', name: '5', x: 60, y: 20 },
 ];
 
-export default function TacticsBoard() {
+function TacticsBoard() {
   const [players, setPlayers] = useState(initialPlayers);
   const boardRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState<string | null>(null);
   const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | null>(null);
 
-  const onDragStart = (e: React.DragEvent, id: string) => {
+  const onDragStart = useCallback((e: React.DragEvent, id: string) => {
     e.dataTransfer.setData('id', id);
-  };
+  }, []);
 
-  const onDrop = (e: React.DragEvent) => {
+  const onDrop = useCallback((e: React.DragEvent) => {
     const id = e.dataTransfer.getData('id');
     const rect = e.currentTarget.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * 100;
     const y = ((e.clientY - rect.top) / rect.height) * 100;
     setPlayers((prev) => prev.map((p) => (p.id === id ? { ...p, x, y } : p)));
-  };
+  }, []);
 
-  const handleLongPress = (id: string) => {
+  const handleLongPress = useCallback((id: string) => {
     setEditing(id);
-  };
+  }, []);
 
-  const startPress = (id: string) => {
-    const timer = setTimeout(() => handleLongPress(id), 500);
-    setPressTimer(timer);
-  };
+  const startPress = useCallback(
+    (id: string) => {
+      const timer = setTimeout(() => handleLongPress(id), 500);
+      setPressTimer(timer);
+    },
+    [handleLongPress],
+  );
 
-  const endPress = () => {
+  const endPress = useCallback(() => {
     if (pressTimer) clearTimeout(pressTimer);
-  };
+  }, [pressTimer]);
 
-  const savePos = (id: string, x: number, y: number) => {
+  const savePos = useCallback((id: string, x: number, y: number) => {
     setPlayers((prev) => prev.map((p) => (p.id === id ? { ...p, x, y } : p)));
     setEditing(null);
-  };
+  }, []);
 
-  const share = async () => {
+  const share = useCallback(async () => {
     if (!boardRef.current) return;
     const canvas = await html2canvas(boardRef.current);
     const url = canvas.toDataURL();
     window.open(`https://wa.me/?text=${encodeURIComponent(url)}`, '_blank');
-  };
+  }, []);
 
   return (
     <div className="space-y-2">
@@ -128,3 +131,5 @@ export default function TacticsBoard() {
     </div>
   );
 }
+export default memo(TacticsBoard);
+

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useState,
+  useMemo,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api, { setAuthToken } from '@/services/api';
@@ -48,10 +49,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener('unauthorized', handler);
   }, [logout, navigate]);
 
+  const value = useMemo(
+    () => ({ token, isAuthenticated: !!token, login, logout }),
+    [token, login, logout],
+  );
+
   return (
-    <AuthContext.Provider
-      value={{ token, isAuthenticated: !!token, login, logout }}
-    >
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { usePlayers } from '@/hooks/usePlayers';
 import { useMatches } from '@/hooks/useMatches';
+import { useMemo, useCallback } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import PlayerQuickInfo from '@/components/PlayerQuickInfo';
 import { useState } from 'react';
@@ -16,23 +17,29 @@ export default function Dashboard() {
   const { data: matches, isLoading: matchesLoading } = useMatches();
   const [selected, setSelected] = useState<string | null>(null);
 
-  const upcoming = matches
-    ? [...matches]
-        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-        .slice(0, 3)
-    : [];
+  const upcoming = useMemo(
+    () =>
+      matches
+        ? [...matches]
+            .sort(
+              (a, b) =>
+                new Date(a.date).getTime() - new Date(b.date).getTime(),
+            )
+            .slice(0, 3)
+        : [],
+    [matches],
+  );
 
-  const averageScore =
-    players && players.length
-      ? (
-          players.reduce((sum, p) => sum + (p.score || 0), 0) / players.length
-        ).toFixed(2)
-      : 'N/A';
+  const averageScore = useMemo(() => {
+    if (!players || !players.length) return 'N/A';
+    const total = players.reduce((sum, p) => sum + (p.score || 0), 0);
+    return (total / players.length).toFixed(2);
+  }, [players]);
 
-  function handleLogout() {
+  const handleLogout = useCallback(() => {
     logout();
     navigate('/login');
-  }
+  }, [logout, navigate]);
 
   return (
     <>

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -4,7 +4,7 @@ import {
   useDeletePlayer,
   useUpdatePlayer,
 } from '@/hooks/usePlayers';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import PlayerWizard from '@/components/PlayerWizard';
 import PlayerCard from '@/components/PlayerCard';
@@ -22,10 +22,13 @@ export default function Players() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
 
-  const handleDelete = (id: string) => {
-    if (!confirm('¿Estás seguro de eliminar este jugador?')) return;
-    deletePlayerMutation.mutate(id);
-  };
+  const handleDelete = useCallback(
+    (id: string) => {
+      if (!confirm('¿Estás seguro de eliminar este jugador?')) return;
+      deletePlayerMutation.mutate(id);
+    },
+    [deletePlayerMutation],
+  );
 
   if (loading)
     return (

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -60,8 +60,8 @@ export default function Register() {
       if (demo) {
         try {
           await createDemoData();
-        } catch (err) {
-          console.error('Demo data error', err);
+        } catch {
+          // ignore demo data errors
         }
       }
       navigate('/login');


### PR DESCRIPTION
## Summary
- memoize frequent renders for `BottomNav`, card components and more
- wrap heavy callbacks with `useCallback`
- cache computed data on Dashboard
- expose memoized auth context value
- silence demo data error logging

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684338b098688330a79b91adf6342111