### PR TITLE
Clean Tailwind usage in frontend

### DIFF
--- a/frontend/src/components/FormationWizard.tsx
+++ b/frontend/src/components/FormationWizard.tsx
@@ -101,12 +101,7 @@ export default function FormationWizard({
           </Button>
         )}
         {step === totalSteps && (
-          <Button
-            variant="success"
-            onClick={finish}
-            disabled={saving}
-            className="flex items-center"
-          >
+          <Button variant="success" onClick={finish} disabled={saving}>
             {saving && <Spinner className="h-4 w-4 mr-2 text-white" />}
             Guardar
           </Button>

--- a/frontend/src/components/PlayerWizard.tsx
+++ b/frontend/src/components/PlayerWizard.tsx
@@ -128,12 +128,7 @@ export default function PlayerWizard({
           </Button>
         )}
         {step === totalSteps && (
-          <Button
-            variant="success"
-            onClick={finish}
-            disabled={saving}
-            className="flex items-center"
-          >
+          <Button variant="success" onClick={finish} disabled={saving}>
             {saving && <Spinner className="h-4 w-4 mr-2 text-white" />}
             Guardar
           </Button>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -69,11 +69,7 @@ export default function Login() {
                 required
               />
             </div>
-            <Button
-              type="submit"
-              className="w-full flex items-center justify-center"
-              disabled={loading}
-            >
+            <Button type="submit" className="w-full" disabled={loading}>
               {loading && <Spinner className="mr-2 h-5 w-5 text-white" />}
               {loading ? 'Ingresando...' : 'Ingresar'}
             </Button>

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -221,11 +221,7 @@ export default function Register() {
           </Button>
         )}
         {step === totalSteps && (
-          <Button
-            type="submit"
-            disabled={loading}
-            className="flex items-center justify-center"
-          >
+          <Button type="submit" disabled={loading}>
             {loading && <Spinner className="mr-2 h-4 w-4 text-white" />}
             Completar
           </Button>


### PR DESCRIPTION
## Summary
- remove redundant flex utilities from Button usages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684338c744308330b3aecbbe153a3441