### PR TITLE
Fix typing issues after refactor

### DIFF
--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import type { Step } from 'react-joyride';
+import type { Step, CallBackProps } from 'react-joyride';
 
-let Joyride: any;
+let Joyride: (typeof import('react-joyride'))['default'] | null = null;
 
 const steps: Step[] = [
   {
@@ -38,7 +38,7 @@ export default function Onboarding() {
         run={run}
         continuous
         showSkipButton
-        callback={(data: any) => {
+        callback={(data: CallBackProps) => {
           if (data.status === 'finished' || data.status === 'skipped') {
             localStorage.setItem('tourDone', 'true');
           }

--- a/frontend/src/components/PlayerWizard.tsx
+++ b/frontend/src/components/PlayerWizard.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import Spinner from '@/components/ui/spinner';
 import { Button } from '@/components/ui/button';
+import type { PlayerStats } from '@/types/player';
 
 export interface PlayerWizardData {
   name: string;
-  stats: Record<string, unknown>;
+  stats: PlayerStats;
 }
 
 export default function PlayerWizard({
@@ -44,7 +45,7 @@ export default function PlayerWizard({
   const finish = async () => {
     try {
       setSaving(true);
-      const parsed = stats ? JSON.parse(stats) : {};
+      const parsed = stats ? (JSON.parse(stats) as PlayerStats) : {};
       await onComplete({ name, stats: parsed });
     } finally {
       setSaving(false);

--- a/frontend/src/components/exports/ExportButtons.tsx
+++ b/frontend/src/components/exports/ExportButtons.tsx
@@ -1,10 +1,10 @@
-import { Player } from '@/types/player';
+import type { Player } from '@/types/player';
 import { type FC, useState, useEffect } from 'react';
 import { Button } from '../ui/button';
 
-let jsPDF: any;
-let html2canvas: any;
-let CSVLink: any;
+let jsPDF: typeof import('jspdf')['default'] | null;
+let html2canvas: typeof import('html2canvas') | null;
+let CSVLink: typeof import('react-csv').CSVLink | null;
 
 export const ExportPlayerPDF: FC<{ player: Player }> = ({ player }) => {
   const generate = async () => {

--- a/frontend/src/hooks/useFormations.ts
+++ b/frontend/src/hooks/useFormations.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../services/api';
-import { Formation, CreateFormationInput } from '../types/formation';
+import type { Formation, CreateFormationInput } from '../types/formation';
 import { toast } from 'sonner';
 
 const fetchFormations = async (): Promise<Formation[]> => {

--- a/frontend/src/hooks/useMatches.ts
+++ b/frontend/src/hooks/useMatches.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { Match } from '@/types/match';
+import type { Match } from '@/types/match';
 import { getMatches } from '@/services/matches';
 
 export function useMatches() {

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../services/api';
 import { toast } from 'sonner';
-import { Player, CreatePlayerInput } from '../types/player';
+import type { Player, CreatePlayerInput } from '../types/player';
 
 const fetchPlayers = async (): Promise<Player[]> => {
   const res = await api.get('/players');

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getStats } from '@/services/stats';
-import { StatItem } from '@/types/stats';
+import type { StatItem } from '@/types/stats';
 
 export function useStats(range: 'month' | 'season') {
   return useQuery<StatItem[]>({

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useAuth } from '@/context/useAuth';
 import { useNavigate, Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { usePlayers } from '@/hooks/usePlayers';
+import type { Player } from '@/types/player';
 import { useMatches } from '@/hooks/useMatches';
 import { Skeleton } from '@/components/ui/skeleton';
 import PlayerQuickInfo from '@/components/PlayerQuickInfo';
@@ -18,16 +19,18 @@ export default function Dashboard() {
 
   const upcoming = matches
     ? [...matches]
-        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+        .sort(
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+        )
         .slice(0, 3)
     : [];
 
-  const averageScore =
-    players && players.length
-      ? (
-          players.reduce((sum, p) => sum + (p.score || 0), 0) / players.length
-        ).toFixed(2)
-      : 'N/A';
+  const averageScore = players
+    ? (
+        players.reduce((sum: number, p: Player) => sum + (p.score || 0), 0) /
+        players.length
+      ).toFixed(2)
+    : 'N/A';
 
   function handleLogout() {
     logout();

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -6,12 +6,16 @@ import {
 } from '@/hooks/usePlayers';
 import { useState } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
-import PlayerWizard from '@/components/PlayerWizard';
+import PlayerWizard, { type PlayerWizardData } from '@/components/PlayerWizard';
 import PlayerCard from '@/components/PlayerCard';
 import { Button } from '@/components/ui/button';
 
 export default function Players() {
-  const { data: players, isLoading: loading, error } = usePlayers();
+  const {
+    data: players = [],
+    isLoading: loading,
+    error,
+  } = usePlayers();
   const createPlayerMutation = useCreatePlayer();
   const deletePlayerMutation = useDeletePlayer();
   const updatePlayerMutation = useUpdatePlayer();
@@ -38,7 +42,10 @@ export default function Players() {
         </div>
       </div>
     );
-  if (error) return <p className="text-red-500 text-center mt-10">{error}</p>;
+  if (error)
+    return (
+      <p className="text-red-500 text-center mt-10">{String(error)}</p>
+    );
 
   return (
     <div className="p-6 space-y-4">
@@ -77,7 +84,7 @@ export default function Players() {
           <PlayerWizard
             initialName={name}
             initialStats={stats}
-            onComplete={async (data) => {
+            onComplete={async (data: PlayerWizardData) => {
               if (isEditMode && editId) {
                 await updatePlayerMutation.mutateAsync({ id: editId, data });
               } else {

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -18,13 +18,14 @@ import {
 import { Button } from '@/components/ui/button';
 import { useStats } from '@/hooks/useStats';
 import Spinner from '@/components/ui/spinner';
+import type { StatItem } from '@/types/stats';
 
 export default function Stats() {
   const [range, setRange] = useState<'month' | 'season'>('month');
   const [selected, setSelected] = useState<string | null>(null);
   const { data, isLoading, error } = useStats(range);
 
-  const stats = data || [];
+  const stats: StatItem[] = data ?? [];
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/Tactics.tsx
+++ b/frontend/src/pages/Tactics.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useFormations, useCreateFormation } from '@/hooks/useFormations';
 import Spinner from '@/components/ui/spinner';
-import FormationWizard from '@/components/FormationWizard';
+import FormationWizard, { type FormationWizardData } from '@/components/FormationWizard';
 import FormationCard from '@/components/FormationCard';
 import { Button } from '@/components/ui/button';
 import TacticsBoard from '@/components/TacticsBoard';
+import type { Formation } from '@/types/formation';
 
 export default function Tactics() {
   const { data: formations = [], isLoading, error } = useFormations();
@@ -20,7 +21,7 @@ export default function Tactics() {
   }
 
   if (error) {
-    return <p className="text-red-500 text-center mt-10">{error}</p>;
+    return <p className="text-red-500 text-center mt-10">{String(error)}</p>;
   }
 
   return (
@@ -38,7 +39,7 @@ export default function Tactics() {
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
-            {formations.map((f) => (
+            {formations.map((f: Formation) => (
               <FormationCard key={f.id} formation={f} />
             ))}
           </div>
@@ -49,7 +50,7 @@ export default function Tactics() {
       {showWizard && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <FormationWizard
-            onComplete={async (data) => {
+            onComplete={async (data: FormationWizardData) => {
               await createFormation.mutateAsync(data);
               setShowWizard(false);
             }}

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from '@tanstack/react-query';
+import { QueryClient, type QueryClientConfig } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import axios from 'axios';
 
@@ -14,18 +14,20 @@ const getMessage = (error: unknown) => {
   return 'Error inesperado';
 };
 
-export const queryClient = new QueryClient({
+const config: QueryClientConfig = {
   defaultOptions: {
     queries: {
       retry: 1,
-      onError: (error) => {
+      onError: (error: unknown) => {
         toast.error(getMessage(error));
       },
     },
     mutations: {
-      onError: (error) => {
+      onError: (error: unknown) => {
         toast.error(getMessage(error));
       },
     },
   },
-});
+};
+
+export const queryClient = new QueryClient(config);

--- a/frontend/src/services/matches.ts
+++ b/frontend/src/services/matches.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { Match } from '../types/match';
+import type { Match } from '../types/match';
 
 export async function getMatches(): Promise<Match[]> {
   const res = await api.get('/matches');

--- a/frontend/src/services/playerService.ts
+++ b/frontend/src/services/playerService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { CreatePlayerInput, Player } from '../types/player';
+import type { CreatePlayerInput, Player } from '../types/player';
 
 export async function createPlayer(data: CreatePlayerInput): Promise<Player> {
   const res = await api.post('/players', data);

--- a/frontend/src/services/stats.ts
+++ b/frontend/src/services/stats.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { StatItem } from '@/types/stats';
+import type { StatItem } from '@/types/stats';
 
 export async function getStats(range: 'month' | 'season'): Promise<StatItem[]> {
   const res = await api.get(`/stats`, { params: { range } });


### PR DESCRIPTION
## Summary
- refine dynamic import types for Joyride
- type export helpers
- use PlayerStats in wizard data
- fix players page state and typing
- add explicit types in dashboard and tactics
- adjust stats page typing
- define QueryClient config with onError handlers
- mark several imports as type-only

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684338fff17c8330a7f06243e6e2c7c8