### PR TITLE
Fix auth token init for PrivateRoute

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -17,16 +17,12 @@ interface AuthContextType {
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [token, setToken] = useState<string | null>(null);
-  const navigate = useNavigate();
-
-  useEffect(() => {
+  const [token, setToken] = useState<string | null>(() => {
     const stored = localStorage.getItem('token');
-    if (stored) {
-      setToken(stored);
-      setAuthToken(stored);
-    }
-  }, []);
+    if (stored) setAuthToken(stored);
+    return stored;
+  });
+  const navigate = useNavigate();
 
   const login = useCallback(async (email: string, password: string) => {
     const res = await api.post('/auth/login', { email, password });


### PR DESCRIPTION
## Summary
- avoid redirecting logged-in users to `/login` on refresh by reading the saved token when the auth context initializes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6843391e71e883308f81e43078bc6c2f