### PR TITLE
Add Jest-compatible tests for missing components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^1.0.0"
+    "vitest": "^1.0.0",
+    "@types/jest": "^29.5.11"
   }
 }

--- a/frontend/src/components/BottomNav.test.tsx
+++ b/frontend/src/components/BottomNav.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import BottomNav from './BottomNav';
+
+beforeAll(() => {
+  window.matchMedia = () => ({ matches: false } as any);
+});
+
+describe('BottomNav', () => {
+  it('renders navigation links', () => {
+    render(
+      <MemoryRouter>
+        <BottomNav />
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText('Inicio')).toBeInTheDocument();
+    expect(screen.getByLabelText('Jugadores')).toBeInTheDocument();
+    expect(screen.getByLabelText('Tácticas')).toBeInTheDocument();
+    expect(screen.getByLabelText('Estadísticas')).toBeInTheDocument();
+    expect(screen.getByLabelText('Perfil')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/FormationCard.test.tsx
+++ b/frontend/src/components/FormationCard.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FormationCard from './FormationCard';
+
+const formation = { id: '1', name: '4-4-2', description: 'desc' } as any;
+
+describe('FormationCard', () => {
+  it('shows formation info', () => {
+    render(<FormationCard formation={formation} />);
+    expect(screen.getByText('4-4-2')).toBeInTheDocument();
+    expect(screen.getByText('desc')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /Compartir/i });
+    expect(link).toHaveAttribute('href', expect.stringContaining('wa.me'));
+  });
+});

--- a/frontend/src/components/FormationWizard.test.tsx
+++ b/frontend/src/components/FormationWizard.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FormationWizard from './FormationWizard';
+import { vi } from 'vitest';
+
+describe('FormationWizard', () => {
+  it('renders first step', () => {
+    render(
+      <FormationWizard onComplete={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(
+      screen.getByText(/Nombre de la formaci/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PlayerCard.test.tsx
+++ b/frontend/src/components/PlayerCard.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlayerCard from './PlayerCard';
+import { vi } from 'vitest';
+
+const player = { id: '1', name: 'John', stats: null } as any;
+
+describe('PlayerCard', () => {
+  it('calls edit and delete handlers', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    window.confirm = vi.fn(() => true);
+    render(
+      <PlayerCard player={player} onEdit={onEdit} onDelete={onDelete} />,
+    );
+    fireEvent.click(screen.getByText('Editar'));
+    expect(onEdit).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Eliminar'));
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ThemeToggle.test.tsx
+++ b/frontend/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ThemeToggle from './ThemeToggle';
+
+describe('ThemeToggle', () => {
+  it('toggles theme', () => {
+    window.matchMedia = () => ({ matches: false } as any);
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-label', 'Activar modo oscuro');
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-label', 'Desactivar modo oscuro');
+  });
+});

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from './Dashboard';
+import { vi } from 'vitest';
+
+vi.mock('@/hooks/usePlayers', () => ({ usePlayers: () => ({ data: [], isLoading: false }) }));
+vi.mock('@/hooks/useMatches', () => ({ useMatches: () => ({ data: [], isLoading: false }) }));
+vi.mock('@/context/useAuth', () => ({ useAuth: () => ({ logout: vi.fn() }) }));
+vi.mock('@/components/Onboarding', () => ({ default: () => <div data-testid="onboarding" /> }));
+
+describe('Dashboard page', () => {
+  it('renders dashboard info', () => {
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/Bienvenido al Dashboard/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Players.test.tsx
+++ b/frontend/src/pages/Players.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Players from './Players';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+vi.mock('@/hooks/usePlayers', () => ({
+  usePlayers: () => ({ data: [], isLoading: false, error: null }),
+  useCreatePlayer: () => ({ mutateAsync: vi.fn() }),
+  useDeletePlayer: () => ({ mutate: vi.fn() }),
+  useUpdatePlayer: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/components/PlayerWizard', () => ({ default: () => <div /> }));
+vi.mock('@/components/PlayerCard', () => ({ default: () => <div>card</div> }));
+
+describe('Players page', () => {
+  it('renders players header', () => {
+    render(
+      <MemoryRouter>
+        <Players />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Jugadores')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Profile.test.tsx
+++ b/frontend/src/pages/Profile.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Profile from './Profile';
+import { vi } from 'vitest';
+
+vi.mock('@/components/ui/input', () => ({ Input: (p: any) => <input {...p} /> }));
+
+describe('Profile page', () => {
+  it('renders profile heading', () => {
+    render(<Profile />);
+    expect(screen.getByText('Perfil del Club')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Stats.test.tsx
+++ b/frontend/src/pages/Stats.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Stats from './Stats';
+import { vi } from 'vitest';
+
+vi.mock('@/hooks/useStats', () => ({ useStats: () => ({ data: [], isLoading: false, error: null }) }));
+
+vi.mock('@/components/ui/spinner', () => ({ default: () => <div /> }));
+
+vi.mock('recharts', () => ({
+  BarChart: (p: any) => <div {...p} />,
+  CartesianGrid: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  Tooltip: () => <div />,
+  Legend: () => <div />,
+  Bar: () => <div />,
+  RadarChart: (p: any) => <div {...p} />,
+  PolarGrid: () => <div />,
+  PolarAngleAxis: () => <div />,
+  PolarRadiusAxis: () => <div />,
+  Radar: () => <div />,
+  LineChart: (p: any) => <div {...p} />,
+  Line: () => <div />,
+}));
+
+describe('Stats page', () => {
+  it('renders heading', () => {
+    render(<Stats />);
+    expect(screen.getByText('Rendimiento')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Tactics.test.tsx
+++ b/frontend/src/pages/Tactics.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Tactics from './Tactics';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+vi.mock('@/hooks/useFormations', () => ({
+  useFormations: () => ({ data: [], isLoading: false, error: null }),
+  useCreateFormation: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/components/FormationWizard', () => ({ default: () => <div /> }));
+vi.mock('@/components/FormationCard', () => ({ default: () => <div>card</div> }));
+vi.mock('@/components/TacticsBoard', () => ({ default: () => <div data-testid="board" /> }));
+
+vi.mock('@/components/ui/spinner', () => ({ default: () => <div /> }));
+
+describe('Tactics page', () => {
+  it('renders formations header', () => {
+    render(
+      <MemoryRouter>
+        <Tactics />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Formaciones')).toBeInTheDocument();
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "types": []
+    "types": ["jest", "node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add @types/jest dev dependency
- enable jest/node types in tsconfig
- create tests for several components and pages that lacked coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843392f63f48330b4c492a3054a8fd4