### PR TITLE
Add integration tests for login and data hooks

### DIFF
--- a/frontend/src/hooks/useFormations.test.tsx
+++ b/frontend/src/hooks/useFormations.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+import { useFormations } from './useFormations';
+import api from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  default: { get: vi.fn() },
+}));
+
+const mockedApi = api as unknown as { get: ReturnType<typeof vi.fn> };
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+describe('useFormations', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetch de formaciones exitoso', async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', name: '4-4-2' }] });
+    const { result } = renderHook(() => useFormations(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: '1', name: '4-4-2' }]);
+  });
+
+  it('fetch de formaciones con error', async () => {
+    mockedApi.get.mockRejectedValueOnce(new Error('fail'));
+    const { result } = renderHook(() => useFormations(), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/frontend/src/hooks/usePlayers.test.tsx
+++ b/frontend/src/hooks/usePlayers.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+import { usePlayers } from './usePlayers';
+import api from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  default: { get: vi.fn() },
+}));
+
+const mockedApi = api as unknown as { get: ReturnType<typeof vi.fn> };
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+describe('usePlayers', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetch de jugadores exitoso', async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', name: 'John' }] });
+    const { result } = renderHook(() => usePlayers(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ id: '1', name: 'John' }]);
+  });
+
+  it('fetch de jugadores con error', async () => {
+    mockedApi.get.mockRejectedValueOnce(new Error('fail'));
+    const { result } = renderHook(() => usePlayers(), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/frontend/src/pages/Login.integration.test.tsx
+++ b/frontend/src/pages/Login.integration.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import Login from './Login';
+import { AuthContext } from '@/context/AuthContext';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+describe('Login integration', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('login exitoso', async () => {
+    const loginMock = vi.fn().mockResolvedValue({});
+    render(
+      <AuthContext.Provider value={{ token: null, isAuthenticated: false, login: loginMock, logout: vi.fn() }}>
+        <MemoryRouter>
+          <Login />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
+    fireEvent.change(screen.getByLabelText('Contraseña'), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Ingresar' }));
+
+    await waitFor(() => expect(loginMock).toHaveBeenCalledWith('test@example.com', '123456'));
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('login fallido', async () => {
+    const loginMock = vi.fn().mockRejectedValue(new Error('fail'));
+    render(
+      <AuthContext.Provider value={{ token: null, isAuthenticated: false, login: loginMock, logout: vi.fn() }}>
+        <MemoryRouter>
+          <Login />
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    );
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
+    fireEvent.change(screen.getByLabelText('Contraseña'), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Ingresar' }));
+
+    await waitFor(() => expect(loginMock).toHaveBeenCalled());
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add integration tests for login success and failure
- test data fetching hooks `usePlayers` and `useFormations`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_684339429d188330babbd21809d804a4