### PR TITLE
Improve accessibility and perf in frontend

### DIFF
--- a/frontend/src/components/PlayerCard.tsx
+++ b/frontend/src/components/PlayerCard.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Player } from '@/types/player';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -9,7 +10,7 @@ interface PlayerCardProps {
   onDelete?: () => void;
 }
 
-export default function PlayerCard({
+function PlayerCard({
   player,
   onEdit,
   onDelete,
@@ -55,3 +56,5 @@ export default function PlayerCard({
     </motion.div>
   );
 }
+
+export default React.memo(PlayerCard);

--- a/frontend/src/components/PlayerQuickInfo.tsx
+++ b/frontend/src/components/PlayerQuickInfo.tsx
@@ -1,12 +1,12 @@
+import React, { useRef, useState, type KeyboardEvent } from 'react';
 import { Player } from '@/types/player';
-import { useRef, useState, type KeyboardEvent } from 'react';
 import { ExportPlayerPDF } from './exports/ExportButtons';
 
 interface PlayerQuickInfoProps {
   player: Player;
 }
 
-export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
+function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
   const tabs = [
     { key: 'stats', label: 'Estadísticas' },
     { key: 'history', label: 'Historial' },
@@ -82,3 +82,5 @@ export default function PlayerQuickInfo({ player }: PlayerQuickInfoProps) {
     </div>
   );
 }
+
+export default React.memo(PlayerQuickInfo);

--- a/frontend/src/components/TacticsBoard.tsx
+++ b/frontend/src/components/TacticsBoard.tsx
@@ -70,13 +70,16 @@ export default function TacticsBoard() {
       {players.map((p) => (
         <div
           key={p.id}
+          role="button"
+          tabIndex={0}
+          aria-label={`Mover ${p.name}`}
           draggable
           onDragStart={(e) => onDragStart(e, p.id)}
           onMouseDown={() => startPress(p.id)}
           onMouseUp={endPress}
           onTouchStart={() => startPress(p.id)}
           onTouchEnd={endPress}
-          className="absolute text-white font-bold cursor-move select-none"
+          className="absolute text-white font-bold cursor-move select-none focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
           style={{ left: `${p.x}%`, top: `${p.y}%` }}
         >
           {p.name}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,7 +5,7 @@ import { usePlayers } from '@/hooks/usePlayers';
 import { useMatches } from '@/hooks/useMatches';
 import { Skeleton } from '@/components/ui/skeleton';
 import PlayerQuickInfo from '@/components/PlayerQuickInfo';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import Onboarding from '@/components/Onboarding';
 
@@ -16,18 +16,23 @@ export default function Dashboard() {
   const { data: matches, isLoading: matchesLoading } = useMatches();
   const [selected, setSelected] = useState<string | null>(null);
 
-  const upcoming = matches
-    ? [...matches]
-        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-        .slice(0, 3)
-    : [];
+  const upcoming = useMemo(
+    () =>
+      matches
+        ? [...matches]
+            .sort(
+              (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+            )
+            .slice(0, 3)
+        : [],
+    [matches],
+  );
 
-  const averageScore =
-    players && players.length
-      ? (
-          players.reduce((sum, p) => sum + (p.score || 0), 0) / players.length
-        ).toFixed(2)
-      : 'N/A';
+  const averageScore = useMemo(() => {
+    if (!players || players.length === 0) return 'N/A';
+    const avg = players.reduce((sum, p) => sum + (p.score || 0), 0) / players.length;
+    return avg.toFixed(2);
+  }, [players]);
 
   function handleLogout() {
     logout();
@@ -107,7 +112,11 @@ export default function Dashboard() {
       </div>
 
       {selected && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+        >
           <div className="bg-white p-4 rounded">
             <PlayerQuickInfo
               player={players!.find((p) => p.id === selected)!}

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -73,7 +73,11 @@ export default function Players() {
       )}
 
       {showModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+        >
           <PlayerWizard
             initialName={name}
             initialStats={stats}

--- a/frontend/src/pages/Tactics.tsx
+++ b/frontend/src/pages/Tactics.tsx
@@ -47,7 +47,11 @@ export default function Tactics() {
       )}
 
       {showWizard && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+        >
           <FormationWizard
             onComplete={async (data) => {
               await createFormation.mutateAsync(data);


### PR DESCRIPTION
## Summary
- add `React.memo` to PlayerCard and PlayerQuickInfo
- memoize expensive calculations in `Dashboard`
- improve keyboard access to `TacticsBoard` players
- mark modal wrappers with dialog roles

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_68433954dd408330857c179011a95a70