### PR TITLE
Improve backend security practices

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,14 +1,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, Logger } from '@nestjs/common';
 import { EntityNotFoundFilter } from './filters/entity-not-found.filter';
 import { env } from './config/env';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const logger = new Logger('Bootstrap');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.useGlobalFilters(new EntityNotFoundFilter());
   await app.listen(env.backendPort);
-  console.log(`🚀 Backend listening on port ${env.backendPort}`);
+  logger.log(`🚀 Backend listening on port ${env.backendPort}`);
 }
 bootstrap();

--- a/backend/src/modules/auth/dto/login.dto.ts
+++ b/backend/src/modules/auth/dto/login.dto.ts
@@ -1,9 +1,10 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
   @IsEmail()
   email!: string;
 
   @IsString()
+  @MinLength(6)
   password!: string;
 }

--- a/backend/src/modules/auth/dto/register.dto.ts
+++ b/backend/src/modules/auth/dto/register.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class RegisterDto {
   @IsString()
@@ -8,5 +8,6 @@ export class RegisterDto {
   email!: string;
 
   @IsString()
+  @MinLength(6)
   password!: string;
 }

--- a/backend/src/modules/ia/ia.service.spec.ts
+++ b/backend/src/modules/ia/ia.service.spec.ts
@@ -79,7 +79,9 @@ describe('IaService', () => {
       .spyOn(httpService, 'post')
       .mockReturnValue(throwError(() => new Error('fail')));
     const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
-    await expect(service.suggestLineup(['x'], '4-4-2')).rejects.toThrow('fail');
+    await expect(service.suggestLineup(['x'], '4-4-2')).rejects.toThrow(
+      'IA service error',
+    );
     expect(logSpy).toHaveBeenCalled();
   });
 
@@ -88,7 +90,7 @@ describe('IaService', () => {
       .spyOn(httpService, 'post')
       .mockReturnValue(throwError(() => new Error('fail')));
     const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
-    await expect(service.suggestTactics(['p'])).rejects.toThrow('fail');
+    await expect(service.suggestTactics(['p'])).rejects.toThrow('IA service error');
     expect(logSpy).toHaveBeenCalled();
   });
 
@@ -97,7 +99,7 @@ describe('IaService', () => {
       .spyOn(httpService, 'post')
       .mockReturnValue(throwError(() => new Error('fail')));
     const logSpy = jest.spyOn<any, any>(service['logger'], 'error');
-    await expect(service.detectErrors(['a'])).rejects.toThrow('fail');
+    await expect(service.detectErrors(['a'])).rejects.toThrow('IA service error');
     expect(logSpy).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/ia/ia.service.ts
+++ b/backend/src/modules/ia/ia.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { LineupResponseDto } from './dto/lineup-response.dto';
@@ -21,7 +21,7 @@ export class IaService {
       return response.data;
     } catch (error) {
       this.logger.error('Failed to suggest lineup', error as Error);
-      throw error;
+      throw new HttpException('IA service error', HttpStatus.BAD_GATEWAY);
     }
   }
 
@@ -36,7 +36,7 @@ export class IaService {
       return response.data;
     } catch (error) {
       this.logger.error('Failed to suggest tactics', error as Error);
-      throw error;
+      throw new HttpException('IA service error', HttpStatus.BAD_GATEWAY);
     }
   }
 
@@ -54,7 +54,7 @@ export class IaService {
       return response.data;
     } catch (error) {
       this.logger.error('Failed to predict match', error as Error);
-      throw error;
+      throw new HttpException('IA service error', HttpStatus.BAD_GATEWAY);
     }
   }
 
@@ -69,7 +69,7 @@ export class IaService {
       return response.data;
     } catch (error) {
       this.logger.error('Failed to detect errors', error as Error);
-      throw error;
+      throw new HttpException('IA service error', HttpStatus.BAD_GATEWAY);
     }
   }
 }


### PR DESCRIPTION
## Summary
- log server startup with Nest `Logger`
- add minimum password length validation
- return generic errors when IA service fails
- update IA service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68433962be1c8330be28a1de2b82bc80