### PR TITLE
Improve backend security and typings

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, Logger } from '@nestjs/common';
 import { EntityNotFoundFilter } from './filters/entity-not-found.filter';
 import { env } from './config/env';
 
@@ -8,7 +8,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.useGlobalFilters(new EntityNotFoundFilter());
+  app.enableCors();
   await app.listen(env.backendPort);
-  console.log(`🚀 Backend listening on port ${env.backendPort}`);
+  Logger.log(`🚀 Backend listening on port ${env.backendPort}`);
 }
 bootstrap();

--- a/backend/src/modules/auth/jwt-payload.interface.ts
+++ b/backend/src/modules/auth/jwt-payload.interface.ts
@@ -1,0 +1,5 @@
+export interface JwtPayload {
+  sub: string;
+  email: string;
+  role: string;
+}

--- a/backend/src/modules/auth/jwt.strategy.ts
+++ b/backend/src/modules/auth/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { env } from '../../config/env';
+import { JwtPayload } from './jwt-payload.interface';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -13,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: JwtPayload) {
     return { userId: payload.sub, email: payload.email, role: payload.role };
   }
 }

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, ILike } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Player } from './player.entity';
 import { RatingsService } from '../ratings/ratings.service';
 
@@ -29,11 +30,13 @@ export class PlayersService {
   }
 
   searchByPosition(position: string): Promise<Player[]> {
-    return this.playersRepo.find({ where: { position: ILike(`%${position}%`) } });
+    return this.playersRepo.find({
+      where: { position: ILike(`%${position}%`) },
+    });
   }
 
   async update(id: string, data: Partial<Player>): Promise<Player> {
-    await this.playersRepo.update(id, data as any);
+    await this.playersRepo.update(id, data as QueryDeepPartialEntity<Player>);
     return this.playersRepo.findOneByOrFail({ id });
   }
 


### PR DESCRIPTION
## Summary
- enable CORS and use `Logger` in main bootstrap
- type JwtStrategy payload and add interface
- tighten update typing in `PlayersService`

## Testing
- `npm run lint`
- `npm test`
- `npx typeorm migration:run --dataSource src/data-source.ts` *(fails: Cannot find module '/workspace/SandeiApp/backend/src/config/env')*

------
https://chatgpt.com/codex/tasks/task_b_6843399d98c08330842a1882b8d7d696