### PR TITLE
Frontend build cleanup and type fixes

### DIFF
--- a/frontend/src/components/FormationWizard.tsx
+++ b/frontend/src/components/FormationWizard.tsx
@@ -96,7 +96,7 @@ export default function FormationWizard({
           <span />
         )}
         {step < totalSteps && (
-          <Button variant="primary" onClick={next}>
+          <Button variant="default" onClick={next}>
             Siguiente
           </Button>
         )}

--- a/frontend/src/components/PlayerWizard.tsx
+++ b/frontend/src/components/PlayerWizard.tsx
@@ -4,7 +4,20 @@ import { Button } from '@/components/ui/button';
 
 export interface PlayerWizardData {
   name: string;
-  stats: Record<string, unknown>;
+  stats: Record<string, number>;
+}
+
+function parseStats(json: string): Record<string, number> {
+  try {
+    const obj = JSON.parse(json) as unknown;
+    if (typeof obj !== 'object' || obj === null) return {};
+    return Object.entries(obj).reduce<Record<string, number>>((acc, [k, v]) => {
+      if (typeof v === 'number') acc[k] = v;
+      return acc;
+    }, {});
+  } catch {
+    return {};
+  }
 }
 
 export default function PlayerWizard({
@@ -44,7 +57,7 @@ export default function PlayerWizard({
   const finish = async () => {
     try {
       setSaving(true);
-      const parsed = stats ? JSON.parse(stats) : {};
+      const parsed = stats ? parseStats(stats) : {};
       await onComplete({ name, stats: parsed });
     } finally {
       setSaving(false);
@@ -123,7 +136,7 @@ export default function PlayerWizard({
           <span />
         )}
         {step < totalSteps && (
-          <Button variant="primary" onClick={next}>
+          <Button variant="default" onClick={next}>
             Siguiente
           </Button>
         )}

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,7 +1,13 @@
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/context/useAuth';
 
-export default function PrivateRoute({ children }: { children: JSX.Element }) {
+import { type ReactElement } from 'react';
+
+export default function PrivateRoute({
+  children,
+}: {
+  children: ReactElement;
+}) {
   const { isAuthenticated } = useAuth();
   return isAuthenticated ? children : <Navigate to="/login" replace />;
 }

--- a/frontend/src/components/TacticsBoard.tsx
+++ b/frontend/src/components/TacticsBoard.tsx
@@ -20,7 +20,7 @@ export default function TacticsBoard() {
   const [players, setPlayers] = useState(initialPlayers);
   const boardRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState<string | null>(null);
-  const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | null>(null);
+  const [pressTimer, setPressTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
 
   const onDragStart = (e: React.DragEvent, id: string) => {
     e.dataTransfer.setData('id', id);

--- a/frontend/src/components/exports/ExportButtons.tsx
+++ b/frontend/src/components/exports/ExportButtons.tsx
@@ -1,10 +1,15 @@
 import { Player } from '@/types/player';
-import { type FC, useState, useEffect } from 'react';
+import { type FC, useState, useEffect, ComponentType } from 'react';
 import { Button } from '../ui/button';
 
-let jsPDF: any;
-let html2canvas: any;
-let CSVLink: any;
+let jsPDF: typeof import('jspdf')['default'] | null = null;
+let html2canvas: typeof import('html2canvas')['default'] | null = null;
+let CSVLink: ComponentType<{
+  data: unknown[] | object;
+  filename?: string;
+  children?: React.ReactNode;
+  className?: string;
+}> | null = null;
 
 export const ExportPlayerPDF: FC<{ player: Player }> = ({ player }) => {
   const generate = async () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,7 +140,7 @@ html {
     @apply border-border outline-ring/50;
   }
   body {
-    @apply text-foreground font-sans pb-16;
+    @apply text-foreground;
     background-color: var(--color-background);
     background-image: linear-gradient(
       to bottom right,
@@ -148,7 +148,10 @@ html {
       var(--color-muted)
     );
   }
-  h1, h2, h3, .font-display {
-    @apply font-display;
+  h1,
+  h2,
+  h3,
+  .font-display {
+    font-family: 'Teko', sans-serif;
   }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
-import App from './App.tsx';
+import App from './App';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import { QueryClientProvider } from '@tanstack/react-query';

--- a/frontend/src/pages/Players.tsx
+++ b/frontend/src/pages/Players.tsx
@@ -11,7 +11,7 @@ import PlayerCard from '@/components/PlayerCard';
 import { Button } from '@/components/ui/button';
 
 export default function Players() {
-  const { data: players, isLoading: loading, error } = usePlayers();
+  const { data: players = [], isLoading: loading, error } = usePlayers();
   const createPlayerMutation = useCreatePlayer();
   const deletePlayerMutation = useDeletePlayer();
   const updatePlayerMutation = useUpdatePlayer();
@@ -38,7 +38,10 @@ export default function Players() {
         </div>
       </div>
     );
-  if (error) return <p className="text-red-500 text-center mt-10">{error}</p>;
+  if (error)
+    return (
+      <p className="text-red-500 text-center mt-10">{String(error)}</p>
+    );
 
   return (
     <div className="p-6 space-y-4">

--- a/frontend/src/pages/Tactics.tsx
+++ b/frontend/src/pages/Tactics.tsx
@@ -20,7 +20,11 @@ export default function Tactics() {
   }
 
   if (error) {
-    return <p className="text-red-500 text-center mt-10">{error}</p>;
+    return (
+      <p className="text-red-500 text-center mt-10">
+        {String(error)}
+      </p>
+    );
   }
 
   return (

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -1,4 +1,8 @@
-import { QueryClient } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryCache,
+  MutationCache,
+} from '@tanstack/react-query';
 import { toast } from 'sonner';
 import axios from 'axios';
 
@@ -15,17 +19,19 @@ const getMessage = (error: unknown) => {
 };
 
 export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => {
+      toast.error(getMessage(error));
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error) => {
+      toast.error(getMessage(error));
+    },
+  }),
   defaultOptions: {
     queries: {
       retry: 1,
-      onError: (error) => {
-        toast.error(getMessage(error));
-      },
-    },
-    mutations: {
-      onError: (error) => {
-        toast.error(getMessage(error));
-      },
     },
   },
 });

--- a/frontend/src/types/react-csv.d.ts
+++ b/frontend/src/types/react-csv.d.ts
@@ -1,0 +1,8 @@
+declare module 'react-csv' {
+  import { ComponentType } from 'react';
+
+  export const CSVLink: ComponentType<{
+    data: unknown[] | object;
+    filename?: string;
+  }>;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,5 +21,11 @@
     },
     "types": []
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- fix runtime UI components and remove invalid variant usages
- harden PlayerWizard parsing and PlayerWizardData types
- refactor queryClient global error handling
- clean up ExportButtons types and provide react-csv typings
- fix various TypeScript errors and adjust Tailwind styles
- exclude test files from production tsconfig

## Testing
- `npm test --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_b_684339b3392c8330ba61954f6943e387