### PR TITLE
Improve backend tests

### DIFF
--- a/backend/test/auth.e2e.spec.ts
+++ b/backend/test/auth.e2e.spec.ts
@@ -1,0 +1,62 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import request from 'supertest';
+
+import { AuthModule } from '../src/modules/auth/auth.module';
+import { User } from '../src/modules/auth/user.entity';
+
+let hasSqlite = true;
+try {
+  require('sqlite3');
+} catch {
+  hasSqlite = false;
+}
+const describeOrSkip = hasSqlite ? describe : describe.skip;
+
+describeOrSkip('AuthModule (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = 'dummy';
+    process.env.JWT_SECRET = 'testsecret';
+    process.env.IA_SERVICE_URL = 'http://localhost';
+    process.env.RABBITMQ_URL = 'amqp://localhost';
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [User],
+          synchronize: true,
+        }),
+        AuthModule,
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('registers and logs in a user', async () => {
+    const payload = { name: 'Test', email: 'user@example.com', password: 'pass' };
+
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send(payload)
+      .expect(201)
+      .expect((res) => expect(res.body.token).toBeDefined());
+
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: payload.email, password: payload.password })
+      .expect(201)
+      .expect((res) => expect(res.body.token).toBeDefined());
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for auth module using supertest and nest testing

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`
- `pytest ia-service`

------
https://chatgpt.com/codex/tasks/task_b_684339ca1014833080d1ed065d7563f7