### PR TITLE
Add Swagger documentation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -43,7 +43,9 @@
     "pg": "^8.16.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "class-transformer": "^0.5.1"
+    "class-transformer": "^0.5.1",
+    "@nestjs/swagger": "^7.2.5",
+    "swagger-ui-express": "^4.7.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.7",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,11 +3,22 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { EntityNotFoundFilter } from './filters/entity-not-found.filter';
 import { env } from './config/env';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.useGlobalFilters(new EntityNotFoundFilter());
+
+  const config = new DocumentBuilder()
+    .setTitle('Sandei API')
+    .setDescription('Sandei REST API documentation')
+    .setVersion('1.0.0')
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
+
   await app.listen(env.backendPort);
   console.log(`🚀 Backend listening on port ${env.backendPort}`);
 }

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -2,12 +2,17 @@ import { Controller, Post, Body } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { ApiTags, ApiOperation, ApiBody, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('register')
+  @ApiOperation({ summary: 'Register new user' })
+  @ApiBody({ type: RegisterDto })
+  @ApiResponse({ status: 201 })
   async register(@Body() registerDto: RegisterDto) {
     return this.authService.register(
       registerDto.name,
@@ -17,6 +22,9 @@ export class AuthController {
   }
 
   @Post('login')
+  @ApiOperation({ summary: 'User login' })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({ status: 201 })
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto.email, loginDto.password);
   }

--- a/backend/src/modules/auth/dto/login.dto.ts
+++ b/backend/src/modules/auth/dto/login.dto.ts
@@ -1,9 +1,12 @@
 import { IsEmail, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsEmail()
   email!: string;
 
+  @ApiProperty({ example: 'mypassword' })
   @IsString()
   password!: string;
 }

--- a/backend/src/modules/auth/dto/register.dto.ts
+++ b/backend/src/modules/auth/dto/register.dto.ts
@@ -1,12 +1,16 @@
 import { IsEmail, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class RegisterDto {
+  @ApiProperty({ example: 'John Doe' })
   @IsString()
   name!: string;
 
+  @ApiProperty({ example: 'user@example.com' })
   @IsEmail()
   email!: string;
 
+  @ApiProperty({ example: 'mypassword' })
   @IsString()
   password!: string;
 }

--- a/backend/src/modules/formations/dto/create-formation.dto.ts
+++ b/backend/src/modules/formations/dto/create-formation.dto.ts
@@ -1,9 +1,12 @@
 import { IsString, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateFormationDto {
+  @ApiProperty({ example: '4-4-2' })
   @IsString()
   name!: string;
 
+  @ApiProperty({ required: false, example: 'Classic formation' })
   @IsOptional()
   @IsString()
   description?: string;

--- a/backend/src/modules/formations/dto/update-formation.dto.ts
+++ b/backend/src/modules/formations/dto/update-formation.dto.ts
@@ -1,10 +1,13 @@
 import { IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateFormationDto {
+  @ApiProperty({ required: false, example: '4-3-3' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiProperty({ required: false, example: 'Offensive style' })
   @IsOptional()
   @IsString()
   description?: string;

--- a/backend/src/modules/formations/formations.controller.ts
+++ b/backend/src/modules/formations/formations.controller.ts
@@ -14,20 +14,35 @@ import { FormationsService } from "./formations.service";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { CreateFormationDto } from "./dto/create-formation.dto";
 import { UpdateFormationDto } from "./dto/update-formation.dto";
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 
-@Controller("formations")
+@ApiTags('formations')
+@ApiBearerAuth()
+@Controller('formations')
 export class FormationsController {
   constructor(private readonly formationsService: FormationsService) {}
 
   @UseGuards(JwtAuthGuard)
   @Get()
+  @ApiOperation({ summary: 'List formations' })
+  @ApiResponse({ status: 200 })
   findAll() {
     return this.formationsService.findAll();
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get(":id")
-  async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
+  @Get(':id')
+  @ApiOperation({ summary: 'Get formation by ID' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200 })
+  async findOne(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
     const formation = await this.formationsService.findById(id);
     if (!formation) throw new NotFoundException("Formation not found");
     return formation;
@@ -36,14 +51,21 @@ export class FormationsController {
   @UseGuards(JwtAuthGuard)
   @Post()
   // Create a new tactical formation
+  @ApiOperation({ summary: 'Create formation' })
+  @ApiBody({ type: CreateFormationDto })
+  @ApiResponse({ status: 201 })
   create(@Body() body: CreateFormationDto) {
     return this.formationsService.create(body);
   }
 
   @UseGuards(JwtAuthGuard)
-  @Put(":id")
+  @Put(':id')
+  @ApiOperation({ summary: 'Update formation' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiBody({ type: UpdateFormationDto })
+  @ApiResponse({ status: 200 })
   async update(
-    @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
     @Body() body: UpdateFormationDto,
   ) {
     const formation = await this.formationsService.update(id, body);
@@ -52,8 +74,11 @@ export class FormationsController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Delete(":id")
-  async remove(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete formation' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200 })
+  async remove(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
     const formation = await this.formationsService.remove(id);
     if (!formation) throw new NotFoundException("Formation not found");
     return { success: true };

--- a/backend/src/modules/ia/dto/error-detection-request.dto.ts
+++ b/backend/src/modules/ia/dto/error-detection-request.dto.ts
@@ -1,11 +1,14 @@
 import { IsArray, ArrayNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ErrorDetectionRequestDto {
+  @ApiProperty({ type: [String], example: ['player1', 'player2'] })
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })
   lineup!: string[];
 
+  @ApiProperty({ required: false, example: '4-4-2' })
   @IsOptional()
   @IsString()
   formation?: string;

--- a/backend/src/modules/ia/dto/error-detection-response.dto.ts
+++ b/backend/src/modules/ia/dto/error-detection-response.dto.ts
@@ -1,3 +1,8 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
 export class ErrorDetectionResponseDto {
+  @ApiProperty({ example: 'No errors found' })
+  @IsString()
   report!: string;
 }

--- a/backend/src/modules/ia/dto/lineup-request.dto.ts
+++ b/backend/src/modules/ia/dto/lineup-request.dto.ts
@@ -1,11 +1,14 @@
 import { IsArray, ArrayNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LineupRequestDto {
+  @ApiProperty({ type: [String], example: ['player1', 'player2'] })
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })
   players!: string[];
 
+  @ApiProperty({ example: '4-4-2' })
   @IsString()
   formation!: string;
 }

--- a/backend/src/modules/ia/dto/lineup-response.dto.ts
+++ b/backend/src/modules/ia/dto/lineup-response.dto.ts
@@ -1,6 +1,8 @@
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LineupResponseDto {
+  @ApiProperty({ example: 'Suggested lineup text' })
   @IsString()
   lineup!: string;
 }

--- a/backend/src/modules/ia/dto/match-prediction-request.dto.ts
+++ b/backend/src/modules/ia/dto/match-prediction-request.dto.ts
@@ -1,11 +1,14 @@
 import { IsArray, ArrayNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class MatchPredictionRequestDto {
+  @ApiProperty({ type: [String], example: ['player1', 'player2'] })
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })
   homeTeam!: string[];
 
+  @ApiProperty({ type: [String], example: ['player3', 'player4'] })
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })

--- a/backend/src/modules/ia/dto/match-prediction-response.dto.ts
+++ b/backend/src/modules/ia/dto/match-prediction-response.dto.ts
@@ -1,6 +1,8 @@
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class MatchPredictionResponseDto {
+  @ApiProperty({ example: 'Home team wins 2-1' })
   @IsString()
   prediction!: string;
 }

--- a/backend/src/modules/ia/dto/tactics-request.dto.ts
+++ b/backend/src/modules/ia/dto/tactics-request.dto.ts
@@ -1,11 +1,14 @@
 import { IsArray, ArrayNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class TacticsRequestDto {
+  @ApiProperty({ type: [String], example: ['player1', 'player2'] })
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })
   players!: string[];
 
+  @ApiProperty({ required: false, example: 'defensive' })
   @IsOptional()
   @IsString()
   style?: string;

--- a/backend/src/modules/ia/dto/tactics-response.dto.ts
+++ b/backend/src/modules/ia/dto/tactics-response.dto.ts
@@ -1,6 +1,8 @@
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class TacticsResponseDto {
+  @ApiProperty({ example: 'Press high and attack on wings' })
   @IsString()
   tactics!: string;
 }

--- a/backend/src/modules/ia/ia.controller.ts
+++ b/backend/src/modules/ia/ia.controller.ts
@@ -9,25 +9,43 @@ import { MatchPredictionRequestDto } from './dto/match-prediction-request.dto';
 import { MatchPredictionResponseDto } from './dto/match-prediction-response.dto';
 import { ErrorDetectionRequestDto } from './dto/error-detection-request.dto';
 import { ErrorDetectionResponseDto } from './dto/error-detection-response.dto';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('ia')
+@ApiBearerAuth()
 @Controller('ia')
 export class IaController {
   constructor(private readonly iaService: IaService) {}
 
   @UseGuards(JwtAuthGuard)
   @Post('suggest_lineup')
+  @ApiOperation({ summary: 'Suggest lineup using AI' })
+  @ApiBody({ type: LineupRequestDto })
+  @ApiResponse({ status: 201, type: LineupResponseDto })
   suggestLineup(@Body() body: LineupRequestDto): Promise<LineupResponseDto> {
     return this.iaService.suggestLineup(body.players, body.formation);
   }
 
   @UseGuards(JwtAuthGuard)
   @Post('suggest_tactics')
+  @ApiOperation({ summary: 'Suggest tactics using AI' })
+  @ApiBody({ type: TacticsRequestDto })
+  @ApiResponse({ status: 201, type: TacticsResponseDto })
   suggestTactics(@Body() body: TacticsRequestDto): Promise<TacticsResponseDto> {
     return this.iaService.suggestTactics(body.players, body.style);
   }
 
   @UseGuards(JwtAuthGuard)
   @Post('predict_match')
+  @ApiOperation({ summary: 'Predict match result with AI' })
+  @ApiBody({ type: MatchPredictionRequestDto })
+  @ApiResponse({ status: 201, type: MatchPredictionResponseDto })
   predictMatch(
     @Body() body: MatchPredictionRequestDto,
   ): Promise<MatchPredictionResponseDto> {
@@ -36,6 +54,9 @@ export class IaController {
 
   @UseGuards(JwtAuthGuard)
   @Post('detect_errors')
+  @ApiOperation({ summary: 'Detect lineup errors with AI' })
+  @ApiBody({ type: ErrorDetectionRequestDto })
+  @ApiResponse({ status: 201, type: ErrorDetectionResponseDto })
   detectErrors(
     @Body() body: ErrorDetectionRequestDto,
   ): Promise<ErrorDetectionResponseDto> {

--- a/backend/src/modules/players/dto/create-player.dto.ts
+++ b/backend/src/modules/players/dto/create-player.dto.ts
@@ -1,25 +1,32 @@
 import { IsString, IsOptional, IsNumber, IsObject } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreatePlayerDto {
+  @ApiProperty({ example: 'John Doe' })
   @IsString()
   name!: string;
 
+  @ApiProperty({ required: false, example: 'Forward' })
   @IsOptional()
   @IsString()
   position?: string;
 
+  @ApiProperty({ required: false, example: 85 })
   @IsOptional()
   @IsNumber()
   score?: number;
 
+  @ApiProperty({ required: false, example: { goals: 5, assists: 3 } })
   @IsOptional()
   @IsObject()
   stats?: Record<string, unknown>;
 
+  @ApiProperty({ required: false, example: 80 })
   @IsOptional()
   @IsNumber()
   fitness?: number;
 
+  @ApiProperty({ required: false, example: 75 })
   @IsOptional()
   @IsNumber()
   technical?: number;

--- a/backend/src/modules/players/dto/update-player.dto.ts
+++ b/backend/src/modules/players/dto/update-player.dto.ts
@@ -1,28 +1,35 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreatePlayerDto } from './create-player.dto';
 import { IsOptional, IsString, IsNumber, IsObject } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdatePlayerDto extends PartialType(CreatePlayerDto) {
+  @ApiProperty({ required: false, example: 'John Doe' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiProperty({ required: false, example: 'Forward' })
   @IsOptional()
   @IsString()
   position?: string;
 
+  @ApiProperty({ required: false, example: 85 })
   @IsOptional()
   @IsNumber()
   score?: number;
 
+  @ApiProperty({ required: false, example: 80 })
   @IsOptional()
   @IsNumber()
   fitness?: number;
 
+  @ApiProperty({ required: false, example: 75 })
   @IsOptional()
   @IsNumber()
   technical?: number;
 
+  @ApiProperty({ required: false, example: { goals: 5 } })
   @IsOptional()
   @IsObject()
   stats?: Record<string, unknown>;

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -10,35 +10,57 @@ import {
   ParseUUIDPipe,
   UseGuards,
 } from "@nestjs/common";
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+  ApiBody,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { PlayersService } from "./players.service";
 import { CreatePlayerDto } from "./dto/create-player.dto";
 import { UpdatePlayerDto } from "./dto/update-player.dto";
 
-@Controller("players")
+@ApiTags('players')
+@ApiBearerAuth()
+@Controller('players')
 export class PlayersController {
   constructor(private readonly playersService: PlayersService) {}
 
   @UseGuards(JwtAuthGuard)
   @Get()
+  @ApiOperation({ summary: 'List all players' })
+  @ApiResponse({ status: 200, description: 'Array of players returned' })
   findAll() {
     return this.playersService.findAll();
   }
 
   @UseGuards(JwtAuthGuard)
   @Get('search')
+  @ApiOperation({ summary: 'Search players by name' })
+  @ApiQuery({ name: 'name', type: String })
+  @ApiResponse({ status: 200 })
   search(@Query('name') name: string) {
     return this.playersService.searchByName(name);
   }
 
   @UseGuards(JwtAuthGuard)
   @Get('position')
+  @ApiOperation({ summary: 'Search players by position' })
+  @ApiQuery({ name: 'position', type: String })
+  @ApiResponse({ status: 200 })
   searchByPosition(@Query('position') position: string) {
     return this.playersService.searchByPosition(position);
   }
 
   @UseGuards(JwtAuthGuard)
   @Get(':id/average-rating')
+  @ApiOperation({ summary: 'Get player average rating' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200 })
   getAverageRating(
     @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
   ) {
@@ -46,29 +68,42 @@ export class PlayersController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get(":id")
-  async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
+  @Get(':id')
+  @ApiOperation({ summary: 'Get player by ID' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200 })
+  async findOne(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
     return this.playersService.findOne(id);
   }
 
   @UseGuards(JwtAuthGuard)
   @Post()
+  @ApiOperation({ summary: 'Create player' })
+  @ApiBody({ type: CreatePlayerDto })
+  @ApiResponse({ status: 201 })
   create(@Body() body: CreatePlayerDto) {
     return this.playersService.create(body);
   }
 
   @UseGuards(JwtAuthGuard)
-  @Put(":id")
+  @Put(':id')
+  @ApiOperation({ summary: 'Update player' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiBody({ type: UpdatePlayerDto })
+  @ApiResponse({ status: 200 })
   async update(
-    @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
     @Body() body: UpdatePlayerDto,
   ) {
     return this.playersService.update(id, body);
   }
 
   @UseGuards(JwtAuthGuard)
-  @Delete(":id")
-  async remove(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete player' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({ status: 200 })
+  async remove(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
     await this.playersService.remove(id);
     return { success: true };
   }

--- a/backend/src/modules/ratings/dto/create-rating.dto.ts
+++ b/backend/src/modules/ratings/dto/create-rating.dto.ts
@@ -1,14 +1,18 @@
 import { IsUUID, IsInt, Min, Max, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateRatingDto {
+  @ApiProperty({ example: 'player-uuid' })
   @IsUUID()
   playerId!: string;
 
+  @ApiProperty({ minimum: 0, maximum: 10, example: 7 })
   @IsInt()
   @Min(0)
   @Max(10)
   score!: number;
 
+  @ApiProperty({ required: false, example: 'Great match!' })
   @IsOptional()
   @IsString()
   comment?: string;

--- a/backend/src/modules/ratings/ratings.controller.ts
+++ b/backend/src/modules/ratings/ratings.controller.ts
@@ -9,13 +9,27 @@ import {
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CreateRatingDto } from './dto/create-rating.dto';
 import { RatingsService } from './ratings.service';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiBody,
+  ApiResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('ratings')
+@ApiBearerAuth()
 @Controller('matches/:matchId/ratings')
 export class RatingsController {
   constructor(private readonly ratingsService: RatingsService) {}
 
   @UseGuards(JwtAuthGuard)
   @Post()
+  @ApiOperation({ summary: 'Create rating for a match' })
+  @ApiParam({ name: 'matchId', type: 'string' })
+  @ApiBody({ type: CreateRatingDto })
+  @ApiResponse({ status: 201 })
   async create(
     @Param('matchId', new ParseUUIDPipe({ version: '4' })) matchId: string,
     @Body() body: CreateRatingDto,


### PR DESCRIPTION
## Summary
- integrate Swagger and expose docs at `/api/docs`
- document players, formations, ratings, auth and IA endpoints
- annotate DTOs with examples for clearer schemas

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@nestjs/swagger')*

------
https://chatgpt.com/codex/tasks/task_b_68433a44ab608330aa3f557c649d349a