### PR TITLE
Fix missing dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/axios": "^4.0.0",
     "@nestjs/mapped-types": "^2.1.0",
+    "helmet": "^7.0.0",
     "axios": "^1.9.0",
     "bcrypt": "^6.0.0",
     "class-validator": "^0.13.2",
@@ -64,6 +65,7 @@
     "eslint": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "@types/supertest": "^2.0.12"
   }
 }


### PR DESCRIPTION
## Summary
- add `helmet` and `@types/supertest` dependencies

## Testing
- `npm --prefix backend test` *(fails: @nestjs/platform-express missing)*
- `(cd ia-service && ./run_tests.sh)` *(fails: ModuleNotFoundError: app)*

------
https://chatgpt.com/codex/tasks/task_b_6845a5ece1588330865637dabade216c