### PR TITLE
Add multi-tenant and Keycloak auth

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,10 +5,12 @@ on:
     branches: [main, dev]
     paths:
       - 'backend/**'
+      - 'docs/multi-tenant-keycloak.md'
   pull_request:
     branches: [main, dev]
     paths:
       - 'backend/**'
+      - 'docs/multi-tenant-keycloak.md'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ El repositorio incluye flujos de GitHub Actions en `.github/workflows/` que ejec
 - `infra/` – Definición de servicios y bases de datos con Docker Compose
 - `docs/` – Documentación adicional
 
+## Nuevos módulos
+- Multi-tenant con `TenantMiddleware` y migraciones.
+- Autenticación centralizada con Keycloak.
+- Módulos de tácticas y scouting de jugadores.
+
 ## Contribuciones
 Las contribuciones son bienvenidas mediante *pull requests*. Asegúrate de seguir una descripción clara de los cambios y asociar los issues correspondientes si existen.
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,8 @@
         "class-validator": "^0.13.2",
         "dotenv": "^10.0.0",
         "helmet": "^7.0.0",
+        "keycloak-connect": "^21.1.1",
+        "nest-keycloak-connect": "^1.10.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.0",
@@ -96,6 +98,30 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@angular-devkit/core/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@angular-devkit/core/node_modules/rxjs": {
       "version": "7.8.1",
@@ -677,7 +703,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -689,7 +715,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -802,22 +828,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -827,12 +837,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -1249,7 +1253,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1266,7 +1269,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -1277,14 +1279,12 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1301,7 +1301,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1803,7 +1802,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1831,7 +1830,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -2133,6 +2132,30 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@nestjs/schematics/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@nestjs/schematics/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nestjs/schematics/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -2309,7 +2332,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -2342,8 +2364,14 @@
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
-      "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
-      "dev": true
+      "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw=="
+    },
+    "node_modules/@testim/chrome-version": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
+      "integrity": "sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.2.7",
@@ -2367,29 +2395,36 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2701,6 +2736,16 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -3083,7 +3128,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3104,7 +3149,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -3112,16 +3157,27 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
@@ -3144,6 +3200,30 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -3195,7 +3275,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -3221,7 +3300,6 @@
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
       "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -3255,7 +3333,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
       "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
-      "dev": true,
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -3270,7 +3347,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3297,6 +3374,31 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3441,14 +3543,12 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3463,6 +3563,16 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/bcrypt": {
       "version": "6.0.0",
@@ -3487,6 +3597,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
+      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -3524,7 +3640,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3540,6 +3655,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.25.0",
@@ -3616,6 +3737,16 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -3773,6 +3904,29 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chromedriver": {
+      "version": "137.0.4",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-137.0.4.tgz",
+      "integrity": "sha512-IxipIe0AnoQhWvG6eSTOLhVf1Tt586LA1IH4RdhGhXrrK6nZx8+VcKdjtlyZIV60S0CttUij/YnYuHAI+7qzWg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@testim/chrome-version": "^1.1.4",
+        "axios": "^1.7.4",
+        "compare-versions": "^6.1.0",
+        "extract-zip": "^2.0.1",
+        "proxy-agent": "^6.4.0",
+        "proxy-from-env": "^1.1.0",
+        "tcp-port-used": "^1.0.2"
+      },
+      "bin": {
+        "chromedriver": "bin/chromedriver"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -3860,7 +4014,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -3874,7 +4027,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3883,7 +4035,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3895,7 +4046,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -3984,6 +4134,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -4141,13 +4298,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4157,11 +4313,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "dev": true
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -4183,7 +4348,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
       "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
-      "dev": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -4197,7 +4361,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -4218,6 +4382,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/delayed-stream": {
@@ -4260,7 +4439,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4335,8 +4514,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -4373,6 +4551,21 @@
       "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
       "dev": true
     },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
@@ -4388,8 +4581,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -4398,6 +4590,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -4473,7 +4675,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4494,6 +4695,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -4584,22 +4817,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4621,12 +4838,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -4673,7 +4884,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -4710,7 +4921,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4719,7 +4930,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4873,6 +5084,43 @@
         "node": ">=4"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4938,7 +5186,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4956,6 +5205,16 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fflate": {
@@ -5100,7 +5359,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -5270,7 +5528,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -5329,6 +5586,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -5484,6 +5756,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5501,6 +5783,17 @@
       "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/html-escaper": {
@@ -5532,6 +5825,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -5643,6 +5964,37 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5686,7 +6038,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5760,11 +6111,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is2": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
+      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "ip-regex": "^4.1.0",
+        "is-url": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=v0.10.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6574,6 +6946,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6599,10 +6978,11 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6671,6 +7051,17 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwk-to-pem": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
+      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "elliptic": "^6.6.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
@@ -6678,6 +7069,22 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keycloak-connect": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-21.1.1.tgz",
+      "integrity": "sha512-FFLhsnXjo+OmzMJpFhHcTjLHLwT18aZi1hJj/TLwXjijyHUFDBdVyD+uF7Hspcs4A4s00xwteAqkQGMlFQa6Yw==",
+      "deprecated": "This package is deprecated and will be removed in the future. We will shortly provide more details on removal date, and recommended alternatives.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwk-to-pem": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "chromedriver": "latest"
       }
     },
     "node_modules/keyv": {
@@ -6860,7 +7267,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -7001,11 +7408,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -7028,7 +7446,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -7119,6 +7536,43 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/nest-keycloak-connect": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/nest-keycloak-connect/-/nest-keycloak-connect-1.10.1.tgz",
+      "integrity": "sha512-tvAYOTPFnxDnQI06jrtcJa6UhyqVtah6V/XwRrNCCL2mklPYnfllGMgVJX0sc3Mca5yJiTVDZOoWruSxnM5qtg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.paypal.me/ferrerojosh/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ferrerojosh"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": ">=6.0.0 <11.0.0",
+        "@nestjs/core": ">=6.0.0 <11.0.0",
+        "@nestjs/graphql": ">=6",
+        "keycloak-connect": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/graphql": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -7369,11 +7823,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -7470,7 +7957,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7524,6 +8010,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/pg": {
       "version": "8.16.0",
@@ -7817,10 +8310,51 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7982,7 +8516,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7992,6 +8525,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8188,28 +8722,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -8298,7 +8810,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -8311,7 +8822,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -8323,7 +8833,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8400,7 +8909,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -8421,6 +8929,47 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
+      "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-map": {
@@ -8469,7 +9018,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/sql-highlight/-/sql-highlight-6.1.0.tgz",
       "integrity": "sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==",
-      "dev": true,
       "funding": [
         "https://github.com/scriptcoded/sql-highlight?sponsor=1",
         {
@@ -8565,7 +9113,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8580,7 +9127,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8594,7 +9140,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8603,7 +9148,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8615,7 +9159,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8624,7 +9167,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8636,7 +9178,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -8652,7 +9193,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -8664,7 +9204,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8809,6 +9348,42 @@
         "node": ">=6"
       }
     },
+    "node_modules/tcp-port-used": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
+      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4.3.1",
+        "is2": "^2.0.6"
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tcp-port-used/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/terser": {
       "version": "5.41.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.41.0.tgz",
@@ -8861,6 +9436,23 @@
         }
       }
     },
+    "node_modules/terser-webpack-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/terser-webpack-plugin/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -8903,6 +9495,13 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "4.3.2",
@@ -9166,7 +9765,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9326,7 +9925,6 @@
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.24.tgz",
       "integrity": "sha512-4IrHG7A0tY8l5gEGXfW56VOMfUVWEkWlH/h5wmcyZ+V8oCiLj7iTPp0lEjMEZVrxEkGSdP9ErgTKHKXQApl/oA==",
-      "dev": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -9432,7 +10030,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9456,7 +10053,6 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -9468,7 +10064,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -9488,7 +10083,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -9502,14 +10096,12 @@
     "node_modules/typeorm/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/typeorm/node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -9525,7 +10117,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9645,7 +10237,6 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
       "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9658,7 +10249,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -9791,6 +10382,23 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/webpack/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -9842,6 +10450,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/webpack/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
@@ -9874,7 +10489,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -9913,7 +10527,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9930,7 +10543,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9939,7 +10551,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10004,7 +10615,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -10019,7 +10629,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -10037,16 +10646,26 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,8 @@
     "class-validator": "^0.13.2",
     "dotenv": "^10.0.0",
     "helmet": "^7.0.0",
+    "keycloak-connect": "^21.1.1",
+    "nest-keycloak-connect": "^1.10.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, MiddlewareConsumer, RequestMethod } from '@nestjs/common';
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { ConfigModule } from "@nestjs/config";
 import { typeOrmConfig } from "./config/typeorm.config";
@@ -11,6 +11,9 @@ import { IaModule } from "./modules/ia/ia.module";
 import { HealthModule } from "./modules/health/health.module";
 import { StatsModule } from "./modules/stats/stats.module";
 import { DemoModule } from "./modules/demo/demo.module";
+import { TacticsModule } from './modules/tactics/tactics.module';
+import { ScoutingModule } from './modules/scouting/scouting.module';
+import { TenantMiddleware } from './modules/common/tenant.middleware';
 
 @Module({
   imports: [
@@ -25,6 +28,14 @@ import { DemoModule } from "./modules/demo/demo.module";
     HealthModule,
     StatsModule,
     DemoModule,
+    TacticsModule,
+    ScoutingModule,
   ],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(TenantMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL });
+  }
+}

--- a/backend/src/migrations/1747088295099-AddTenantId.ts
+++ b/backend/src/migrations/1747088295099-AddTenantId.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddTenantId1747088295099 implements MigrationInterface {
+    name = 'AddTenantId1747088295099'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "players" ADD "tenantId" uuid`);
+        await queryRunner.query(`ALTER TABLE "match" ADD "tenantId" uuid`);
+        await queryRunner.query(`ALTER TABLE "rating" ADD "tenantId" uuid`);
+        await queryRunner.query(`ALTER TABLE "user" ADD "tenantId" uuid`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "tenantId"`);
+        await queryRunner.query(`ALTER TABLE "rating" DROP COLUMN "tenantId"`);
+        await queryRunner.query(`ALTER TABLE "match" DROP COLUMN "tenantId"`);
+        await queryRunner.query(`ALTER TABLE "players" DROP COLUMN "tenantId"`);
+    }
+}

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -7,6 +7,8 @@ import { AuthController } from './auth.controller';
 import { User } from './user.entity';
 import { JwtStrategy } from './jwt.strategy';
 import { env } from '../../config/env';
+import { KeycloakModule } from './keycloak.module';
+import { KeycloakAuthGuard } from './keycloak-auth.guard';
 
 @Module({
   imports: [
@@ -16,9 +18,10 @@ import { env } from '../../config/env';
       secret: env.jwtSecret,
       signOptions: { expiresIn: '1h' },
     }),
+    KeycloakModule,
   ],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, KeycloakAuthGuard],
   controllers: [AuthController],
-  exports: [AuthService],
+  exports: [AuthService, KeycloakAuthGuard, KeycloakModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/keycloak-auth.guard.ts
+++ b/backend/src/modules/auth/keycloak-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from 'nest-keycloak-connect';
+
+@Injectable()
+export class KeycloakAuthGuard extends AuthGuard {}

--- a/backend/src/modules/auth/keycloak.module.ts
+++ b/backend/src/modules/auth/keycloak.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { KeycloakConnectModule } from 'nest-keycloak-connect';
+import { ConfigService } from '@nestjs/config';
+
+@Module({
+  imports: [
+    KeycloakConnectModule.registerAsync({
+      useFactory: (config: ConfigService) => ({
+        authServerUrl: config.get('KEYCLOAK_URL'),
+        realm: config.get('KEYCLOAK_REALM'),
+        clientId: config.get('KEYCLOAK_CLIENT_ID'),
+        secret: config.getOrThrow('KEYCLOAK_CLIENT_SECRET'),
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+  exports: [KeycloakConnectModule],
+})
+export class KeycloakModule {}

--- a/backend/src/modules/auth/user.entity.ts
+++ b/backend/src/modules/auth/user.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, Column } from 'typeorm';
+import { TenantEntity } from '../common/tenant.entity';
 
 export enum UserRole {
   USER = 'user',
@@ -6,9 +7,7 @@ export enum UserRole {
 }
 
 @Entity()
-export class User {
-  @PrimaryGeneratedColumn('uuid')
-  id!: string;
+export class User extends TenantEntity {
 
   @Column()
   name!: string;

--- a/backend/src/modules/common/tenant.entity.ts
+++ b/backend/src/modules/common/tenant.entity.ts
@@ -1,0 +1,9 @@
+import { PrimaryGeneratedColumn, Column } from 'typeorm';
+
+export abstract class TenantEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  tenantId!: string;
+}

--- a/backend/src/modules/common/tenant.middleware.ts
+++ b/backend/src/modules/common/tenant.middleware.ts
@@ -1,0 +1,13 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class TenantMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction) {
+    const tenantId = req.headers['x-tenant-id'];
+    if (typeof tenantId === 'string') {
+      (req as any).tenantId = tenantId;
+    }
+    next();
+  }
+}

--- a/backend/src/modules/demo/demo.controller.ts
+++ b/backend/src/modules/demo/demo.controller.ts
@@ -1,12 +1,12 @@
 import { Controller, Post, UseGuards } from '@nestjs/common';
 import { DemoService } from './demo.service';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { KeycloakAuthGuard } from '../auth/keycloak-auth.guard';
 
 @Controller('demo')
 export class DemoController {
   constructor(private readonly demo: DemoService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post()
   createDemo() {
     return this.demo.createDemoData();

--- a/backend/src/modules/demo/demo.service.ts
+++ b/backend/src/modules/demo/demo.service.ts
@@ -12,6 +12,7 @@ export class DemoService {
   ) {}
 
   async createDemoData() {
+    const tenant = 'demo';
     const playerPromises = Array.from({ length: 11 }).map((_, i) =>
       this.players.create({
         name: `Demo ${i + 1}`,
@@ -19,14 +20,14 @@ export class DemoService {
         score: Math.floor(Math.random() * 10),
         technical: Math.floor(Math.random() * 10),
         fitness: Math.floor(Math.random() * 10),
-      }),
+      }, tenant),
     );
     const players = await Promise.all(playerPromises);
 
-    const match1 = await this.matches.create({ date: new Date() });
+    const match1 = await this.matches.create({ date: new Date() }, tenant);
     const match2 = await this.matches.create({
       date: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
-    });
+    }, tenant);
 
     for (const match of [match1, match2]) {
       for (const player of players) {

--- a/backend/src/modules/formations/__tests__/formations.controller.spec.ts
+++ b/backend/src/modules/formations/__tests__/formations.controller.spec.ts
@@ -22,7 +22,10 @@ describe('FormationsController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(require('../../auth/keycloak-auth.guard').KeycloakAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<FormationsController>(FormationsController);
     service = module.get<FormationsService>(FormationsService);

--- a/backend/src/modules/formations/formations.controller.ts
+++ b/backend/src/modules/formations/formations.controller.ts
@@ -11,7 +11,7 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { FormationsService } from "./formations.service";
-import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { KeycloakAuthGuard } from "../auth/keycloak-auth.guard";
 import { CreateFormationDto } from "./dto/create-formation.dto";
 import { UpdateFormationDto } from "./dto/update-formation.dto";
 import {
@@ -29,7 +29,7 @@ import {
 export class FormationsController {
   constructor(private readonly formationsService: FormationsService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get()
   @ApiOperation({ summary: 'List formations' })
   @ApiResponse({ status: 200 })
@@ -37,7 +37,7 @@ export class FormationsController {
     return this.formationsService.findAll();
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get(':id')
   @ApiOperation({ summary: 'Get formation by ID' })
   @ApiParam({ name: 'id', type: 'string' })
@@ -48,7 +48,7 @@ export class FormationsController {
     return formation;
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post()
   // Create a new tactical formation
   @ApiOperation({ summary: 'Create formation' })
@@ -58,7 +58,7 @@ export class FormationsController {
     return this.formationsService.create(body);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Put(':id')
   @ApiOperation({ summary: 'Update formation' })
   @ApiParam({ name: 'id', type: 'string' })
@@ -73,7 +73,7 @@ export class FormationsController {
     return formation;
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Delete(':id')
   @ApiOperation({ summary: 'Delete formation' })
   @ApiParam({ name: 'id', type: 'string' })

--- a/backend/src/modules/ia/ia.controller.spec.ts
+++ b/backend/src/modules/ia/ia.controller.spec.ts
@@ -9,7 +9,7 @@ import { Test } from '@nestjs/testing';
 import { INestApplication, HttpStatus } from '@nestjs/common';
 import { IaModule } from './ia.module';
 import { HttpService } from '@nestjs/axios';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { KeycloakAuthGuard } from '../auth/keycloak-auth.guard';
 import { of } from 'rxjs';
 import { AxiosResponse } from 'axios';
 import request from 'supertest';
@@ -24,7 +24,7 @@ describe('IaController', () => {
     })
       .overrideProvider(HttpService)
       .useValue({ post: jest.fn() })
-      .overrideGuard(JwtAuthGuard)
+      .overrideGuard(KeycloakAuthGuard)
       .useValue({ canActivate: () => true })
       .compile();
 

--- a/backend/src/modules/ia/ia.controller.ts
+++ b/backend/src/modules/ia/ia.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { IaService } from './ia.service';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { KeycloakAuthGuard } from '../auth/keycloak-auth.guard';
 import { LineupRequestDto } from './dto/lineup-request.dto';
 import { LineupResponseDto } from './dto/lineup-response.dto';
 import { TacticsRequestDto } from './dto/tactics-request.dto';
@@ -23,7 +23,7 @@ import {
 export class IaController {
   constructor(private readonly iaService: IaService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post('suggest_lineup')
   @ApiOperation({ summary: 'Suggest lineup using AI' })
   @ApiBody({ type: LineupRequestDto })
@@ -32,7 +32,7 @@ export class IaController {
     return this.iaService.suggestLineup(body.players, body.formation);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post('suggest_tactics')
   @ApiOperation({ summary: 'Suggest tactics using AI' })
   @ApiBody({ type: TacticsRequestDto })
@@ -41,7 +41,7 @@ export class IaController {
     return this.iaService.suggestTactics(body.players, body.style);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post('predict_match')
   @ApiOperation({ summary: 'Predict match result with AI' })
   @ApiBody({ type: MatchPredictionRequestDto })
@@ -52,7 +52,7 @@ export class IaController {
     return this.iaService.predictMatch(body.homeTeam, body.awayTeam);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post('detect_errors')
   @ApiOperation({ summary: 'Detect lineup errors with AI' })
   @ApiBody({ type: ErrorDetectionRequestDto })

--- a/backend/src/modules/matches/__tests__/matches.service.spec.ts
+++ b/backend/src/modules/matches/__tests__/matches.service.spec.ts
@@ -1,4 +1,7 @@
 process.env.RABBITMQ_URL = 'amqp://localhost';
+process.env.DATABASE_URL = 'dummy';
+process.env.JWT_SECRET = 'secret';
+process.env.IA_SERVICE_URL = 'http://localhost';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, EntityNotFoundError } from 'typeorm';
@@ -38,25 +41,26 @@ describe('MatchesService', () => {
 
   it('creates a match', async () => {
     const data = { location: 'A' } as Partial<Match>;
-    (repo.create as jest.Mock).mockReturnValue(data);
-    (repo.save as jest.Mock).mockResolvedValue({ id: '1', ...data });
+    const created = { ...data, tenantId: 't1' } as Match;
+    (repo.create as jest.Mock).mockReturnValue(created);
+    (repo.save as jest.Mock).mockResolvedValue({ ...created, id: '1' });
 
-    const result = await service.create(data);
-    expect(repo.create).toHaveBeenCalledWith(data);
-    expect(repo.save).toHaveBeenCalledWith(data);
-    expect(rabbit.publish).toHaveBeenCalledWith('matches.created', { id: '1', ...data });
-    expect(result).toEqual({ id: '1', ...data });
+    const result = await service.create(data, 't1');
+    expect(repo.create).toHaveBeenCalledWith({ ...data, tenantId: 't1' });
+    expect(repo.save).toHaveBeenCalledWith({ ...data, tenantId: 't1' });
+    expect(rabbit.publish).toHaveBeenCalledWith('matches.created', { ...created, id: '1' });
+    expect(result).toEqual({ ...created, id: '1' });
   });
 
   it('removes a match if found', async () => {
     const match = { id: '1' } as Match;
     (repo.findOneByOrFail as jest.Mock).mockResolvedValue(match);
-    await service.remove('1');
+    await service.remove('1', 't1');
     expect(repo.remove).toHaveBeenCalledWith(match);
   });
 
   it('throws EntityNotFoundError when removing missing match', async () => {
     (repo.findOneByOrFail as jest.Mock).mockRejectedValue(new EntityNotFoundError(Match, 'test'));
-    await expect(service.remove('nope')).rejects.toBeInstanceOf(EntityNotFoundError);
+    await expect(service.remove('nope', 't1')).rejects.toBeInstanceOf(EntityNotFoundError);
   });
 });

--- a/backend/src/modules/matches/match.entity.ts
+++ b/backend/src/modules/matches/match.entity.ts
@@ -1,9 +1,8 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, Column } from 'typeorm';
+import { TenantEntity } from '../common/tenant.entity';
 
 @Entity('match')
-export class Match {
-  @PrimaryGeneratedColumn('uuid')
-  id!: string;
+export class Match extends TenantEntity {
 
   @Column({ type: 'timestamp', default: () => 'NOW()' })
   date!: Date;

--- a/backend/src/modules/matches/matches.controller.ts
+++ b/backend/src/modules/matches/matches.controller.ts
@@ -8,47 +8,61 @@ import {
   Body,
   ParseUUIDPipe,
   UseGuards,
+  Req,
 } from "@nestjs/common";
 import { MatchesService } from "./matches.service";
 import { CreateMatchDto } from "./dto/create-match.dto";
 import { UpdateMatchDto } from "./dto/update-match.dto";
-import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { Request } from 'express';
+import { KeycloakAuthGuard } from "../auth/keycloak-auth.guard";
 
 @Controller("matches")
 export class MatchesController {
   constructor(private readonly matchesService: MatchesService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get()
-  findAll() {
-    return this.matchesService.findAll();
+  findAll(@Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.matchesService.findAll(tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get(":id")
-  async findOne(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
-    return this.matchesService.findById(id);
+  async findOne(
+    @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
+    @Req() req: Request,
+  ) {
+    const tenantId = (req as any).tenantId as string;
+    return this.matchesService.findById(id, tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post()
-  create(@Body() body: CreateMatchDto) {
-    return this.matchesService.create(body);
+  create(@Body() body: CreateMatchDto, @Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.matchesService.create(body, tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Put(":id")
   async update(
     @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
     @Body() body: UpdateMatchDto,
+    @Req() req: Request,
   ) {
-    return this.matchesService.update(id, body);
+    const tenantId = (req as any).tenantId as string;
+    return this.matchesService.update(id, tenantId, body);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Delete(":id")
-  async remove(@Param("id", new ParseUUIDPipe({ version: "4" })) id: string) {
-    await this.matchesService.remove(id);
+  async remove(
+    @Param("id", new ParseUUIDPipe({ version: "4" })) id: string,
+    @Req() req: Request,
+  ) {
+    const tenantId = (req as any).tenantId as string;
+    await this.matchesService.remove(id, tenantId);
     return { success: true };
   }
 }

--- a/backend/src/modules/matches/matches.service.ts
+++ b/backend/src/modules/matches/matches.service.ts
@@ -11,28 +11,28 @@ export class MatchesService {
     private readonly rabbit: RabbitMQService,
   ) {}
 
-  async create(data: Partial<Match>) {
-    const match = this.matchesRepo.create(data);
+  async create(data: Partial<Match>, tenantId: string) {
+    const match = this.matchesRepo.create({ ...data, tenantId });
     const saved = await this.matchesRepo.save(match);
     await this.rabbit.publish('matches.created', saved);
     return saved;
   }
 
-  findAll() {
-    return this.matchesRepo.find();
+  findAll(tenantId: string) {
+    return this.matchesRepo.find({ where: { tenantId } });
   }
 
-  findById(id: string) {
-    return this.matchesRepo.findOneByOrFail({ id });
+  findById(id: string, tenantId: string) {
+    return this.matchesRepo.findOneByOrFail({ id, tenantId });
   }
 
-  async update(id: string, data: Partial<Match>) {
-    await this.matchesRepo.update(id, data);
-    return this.matchesRepo.findOneByOrFail({ id });
+  async update(id: string, tenantId: string, data: Partial<Match>) {
+    await this.matchesRepo.update({ id, tenantId }, data);
+    return this.matchesRepo.findOneByOrFail({ id, tenantId });
   }
 
-  async remove(id: string) {
-    const match = await this.matchesRepo.findOneByOrFail({ id });
+  async remove(id: string, tenantId: string) {
+    const match = await this.matchesRepo.findOneByOrFail({ id, tenantId });
     await this.matchesRepo.remove(match);
     return match;
   }

--- a/backend/src/modules/players/__tests__/players.controller.spec.ts
+++ b/backend/src/modules/players/__tests__/players.controller.spec.ts
@@ -26,7 +26,10 @@ describe('PlayersController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(require('../../auth/keycloak-auth.guard').KeycloakAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<PlayersController>(PlayersController);
     service = module.get<PlayersService>(PlayersService);
@@ -34,26 +37,26 @@ describe('PlayersController', () => {
 
   it('throws EntityNotFoundError when player not found', async () => {
     (service.findOne as jest.Mock).mockRejectedValue(new EntityNotFoundError(Player, 'test'));
-    await expect(controller.findOne('x')).rejects.toBeInstanceOf(EntityNotFoundError);
+    await expect(controller.findOne('x', { tenantId: 't1' } as any)).rejects.toBeInstanceOf(EntityNotFoundError);
   });
 
   it('calls service to create a player', () => {
-    controller.create({ name: 'test', stats: {}, fitness: 10, technical: 20 } as any);
+    controller.create({ name: 'test', stats: {}, fitness: 10, technical: 20 } as any, { tenantId: 't1' } as any);
     expect(service.create).toHaveBeenCalled();
   });
 
   it('searches players', () => {
-    controller.search('john');
-    expect(service.searchByName).toHaveBeenCalledWith('john');
+    controller.search('john', { tenantId: 't1' } as any);
+    expect(service.searchByName).toHaveBeenCalledWith('john', 't1');
   });
 
   it('searches players by position', () => {
-    controller.searchByPosition('forward');
-    expect(service.searchByPosition).toHaveBeenCalledWith('forward');
+    controller.searchByPosition('forward', { tenantId: 't1' } as any);
+    expect(service.searchByPosition).toHaveBeenCalledWith('forward', 't1');
   });
 
   it('gets average rating', () => {
-    controller.getAverageRating('id');
-    expect(service.getAverageRating).toHaveBeenCalledWith('id');
+    controller.getAverageRating('id', { tenantId: 't1' } as any);
+    expect(service.getAverageRating).toHaveBeenCalledWith('id', 't1');
   });
 });

--- a/backend/src/modules/players/__tests__/players.service.spec.ts
+++ b/backend/src/modules/players/__tests__/players.service.spec.ts
@@ -40,40 +40,41 @@ describe('PlayersService', () => {
       fitness: 50,
       technical: 60,
     } as Partial<Player>;
-    (repo.create as jest.Mock).mockReturnValue(data);
-    (repo.save as jest.Mock).mockResolvedValue({ id: '1', ...data });
+    const created = { ...data, tenantId: 't1' } as Player;
+    (repo.create as jest.Mock).mockReturnValue(created);
+    (repo.save as jest.Mock).mockResolvedValue({ ...created, id: '1' });
 
-    const result = await service.create(data);
-    expect(repo.create).toHaveBeenCalledWith(data);
-    expect(repo.save).toHaveBeenCalledWith(data);
-    expect(result).toEqual({ id: '1', ...data });
+    const result = await service.create(data, 't1');
+    expect(repo.create).toHaveBeenCalledWith({ ...data, tenantId: 't1' });
+    expect(repo.save).toHaveBeenCalledWith({ ...data, tenantId: 't1' });
+    expect(result).toEqual({ ...created, id: '1' });
   });
 
   it('removes a player if found', async () => {
     const player = { id: '1' } as Player;
     (repo.findOneByOrFail as jest.Mock).mockResolvedValue(player);
-    await service.remove('1');
+    await service.remove('1', 't1');
     expect(repo.remove).toHaveBeenCalledWith(player);
   });
 
   it('searches players by name', async () => {
     const players = [{ id: '1', name: 'John' }] as Player[];
     (repo.find as jest.Mock).mockResolvedValue(players);
-    const result = await service.searchByName('jo');
-    expect(repo.find).toHaveBeenCalledWith({ where: { name: expect.anything() } });
+    const result = await service.searchByName('jo', 't1');
+    expect(repo.find).toHaveBeenCalledWith({ where: { name: expect.anything(), tenantId: 't1' } });
     expect(result).toEqual(players);
   });
 
   it('searches players by position', async () => {
     const players = [{ id: '1', position: 'Forward' }] as Player[];
     (repo.find as jest.Mock).mockResolvedValue(players);
-    const result = await service.searchByPosition('for');
-    expect(repo.find).toHaveBeenCalledWith({ where: { position: expect.anything() } });
+    const result = await service.searchByPosition('for', 't1');
+    expect(repo.find).toHaveBeenCalledWith({ where: { position: expect.anything(), tenantId: 't1' } });
     expect(result).toEqual(players);
   });
 
   it('throws EntityNotFoundError when removing missing player', async () => {
     (repo.findOneByOrFail as jest.Mock).mockRejectedValue(new EntityNotFoundError(Player, 'test'));
-    await expect(service.remove('nope')).rejects.toBeInstanceOf(EntityNotFoundError);
+    await expect(service.remove('nope', 't1')).rejects.toBeInstanceOf(EntityNotFoundError);
   });
 });

--- a/backend/src/modules/players/player.entity.ts
+++ b/backend/src/modules/players/player.entity.ts
@@ -1,9 +1,8 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, Column } from 'typeorm';
+import { TenantEntity } from '../common/tenant.entity';
 
 @Entity('players')
-export class Player {
-  @PrimaryGeneratedColumn('uuid')
-  id!: string;
+export class Player extends TenantEntity {
 
   @Column()
   name!: string;

--- a/backend/src/modules/players/players.controller.ts
+++ b/backend/src/modules/players/players.controller.ts
@@ -9,6 +9,7 @@ import {
   Query,
   ParseUUIDPipe,
   UseGuards,
+  Req,
 } from "@nestjs/common";
 import {
   ApiTags,
@@ -19,10 +20,11 @@ import {
   ApiQuery,
   ApiBody,
 } from '@nestjs/swagger';
-import { JwtAuthGuard } from "../auth/jwt-auth.guard";
+import { KeycloakAuthGuard } from "../auth/keycloak-auth.guard";
 import { PlayersService } from "./players.service";
 import { CreatePlayerDto } from "./dto/create-player.dto";
 import { UpdatePlayerDto } from "./dto/update-player.dto";
+import { Request } from 'express';
 
 @ApiTags('players')
 @ApiBearerAuth()
@@ -30,62 +32,72 @@ import { UpdatePlayerDto } from "./dto/update-player.dto";
 export class PlayersController {
   constructor(private readonly playersService: PlayersService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get()
   @ApiOperation({ summary: 'List all players' })
   @ApiResponse({ status: 200, description: 'Array of players returned' })
-  findAll() {
-    return this.playersService.findAll();
+  findAll(@Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.playersService.findAll(tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get('search')
   @ApiOperation({ summary: 'Search players by name' })
   @ApiQuery({ name: 'name', type: String })
   @ApiResponse({ status: 200 })
-  search(@Query('name') name: string) {
-    return this.playersService.searchByName(name);
+  search(@Query('name') name: string, @Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.playersService.searchByName(name, tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get('position')
   @ApiOperation({ summary: 'Search players by position' })
   @ApiQuery({ name: 'position', type: String })
   @ApiResponse({ status: 200 })
-  searchByPosition(@Query('position') position: string) {
-    return this.playersService.searchByPosition(position);
+  searchByPosition(@Query('position') position: string, @Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.playersService.searchByPosition(position, tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get(':id/average-rating')
   @ApiOperation({ summary: 'Get player average rating' })
   @ApiParam({ name: 'id', type: 'string' })
   @ApiResponse({ status: 200 })
   getAverageRating(
     @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+    @Req() req: Request,
   ) {
-    return this.playersService.getAverageRating(id);
+    const tenantId = (req as any).tenantId as string;
+    return this.playersService.getAverageRating(id, tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get(':id')
   @ApiOperation({ summary: 'Get player by ID' })
   @ApiParam({ name: 'id', type: 'string' })
   @ApiResponse({ status: 200 })
-  async findOne(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
-    return this.playersService.findOne(id);
+  async findOne(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+    @Req() req: Request,
+  ) {
+    const tenantId = (req as any).tenantId as string;
+    return this.playersService.findOne(id, tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post()
   @ApiOperation({ summary: 'Create player' })
   @ApiBody({ type: CreatePlayerDto })
   @ApiResponse({ status: 201 })
-  create(@Body() body: CreatePlayerDto) {
-    return this.playersService.create(body);
+  create(@Body() body: CreatePlayerDto, @Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.playersService.create(body, tenantId);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Put(':id')
   @ApiOperation({ summary: 'Update player' })
   @ApiParam({ name: 'id', type: 'string' })
@@ -94,17 +106,23 @@ export class PlayersController {
   async update(
     @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
     @Body() body: UpdatePlayerDto,
+    @Req() req: Request,
   ) {
-    return this.playersService.update(id, body);
+    const tenantId = (req as any).tenantId as string;
+    return this.playersService.update(id, tenantId, body);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Delete(':id')
   @ApiOperation({ summary: 'Delete player' })
   @ApiParam({ name: 'id', type: 'string' })
   @ApiResponse({ status: 200 })
-  async remove(@Param('id', new ParseUUIDPipe({ version: '4' })) id: string) {
-    await this.playersService.remove(id);
+  async remove(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+    @Req() req: Request,
+  ) {
+    const tenantId = (req as any).tenantId as string;
+    await this.playersService.remove(id, tenantId);
     return { success: true };
   }
 }

--- a/backend/src/modules/players/players.service.ts
+++ b/backend/src/modules/players/players.service.ts
@@ -12,41 +12,42 @@ export class PlayersService {
     private readonly ratingsService: RatingsService,
   ) {}
 
-  create(data: Partial<Player>): Promise<Player> {
-    const player = this.playersRepo.create(data);
+  create(data: Partial<Player>, tenantId: string): Promise<Player> {
+    const player = this.playersRepo.create({ ...data, tenantId });
     return this.playersRepo.save(player);
   }
 
-  findAll(): Promise<Player[]> {
-    return this.playersRepo.find();
+  findAll(tenantId: string): Promise<Player[]> {
+    return this.playersRepo.find({ where: { tenantId } });
   }
 
-  findOne(id: string): Promise<Player> {
-    return this.playersRepo.findOneByOrFail({ id });
+  findOne(id: string, tenantId: string): Promise<Player> {
+    return this.playersRepo.findOneByOrFail({ id, tenantId });
   }
 
-  searchByName(name: string): Promise<Player[]> {
-    return this.playersRepo.find({ where: { name: ILike(`%${name}%`) } });
+  searchByName(name: string, tenantId: string): Promise<Player[]> {
+    return this.playersRepo.find({ where: { name: ILike(`%${name}%`), tenantId } });
   }
 
-  searchByPosition(position: string): Promise<Player[]> {
+  searchByPosition(position: string, tenantId: string): Promise<Player[]> {
     return this.playersRepo.find({
-      where: { position: ILike(`%${position}%`) },
+      where: { position: ILike(`%${position}%`), tenantId },
     });
   }
 
-  async update(id: string, data: Partial<Player>): Promise<Player> {
-    await this.playersRepo.update(id, data as QueryDeepPartialEntity<Player>);
-    return this.playersRepo.findOneByOrFail({ id });
+  async update(id: string, tenantId: string, data: Partial<Player>): Promise<Player> {
+    await this.playersRepo.update({ id, tenantId }, data as QueryDeepPartialEntity<Player>);
+    return this.playersRepo.findOneByOrFail({ id, tenantId });
   }
 
-  async remove(id: string): Promise<Player> {
-    const player = await this.playersRepo.findOneByOrFail({ id });
+  async remove(id: string, tenantId: string): Promise<Player> {
+    const player = await this.playersRepo.findOneByOrFail({ id, tenantId });
     await this.playersRepo.remove(player);
     return player;
   }
 
-  getAverageRating(id: string): Promise<number> {
+  getAverageRating(id: string, tenantId: string): Promise<number> {
+    void tenantId;
     return this.ratingsService.averageForPlayer(id);
   }
 }

--- a/backend/src/modules/ratings/__tests__/ratings.controller.spec.ts
+++ b/backend/src/modules/ratings/__tests__/ratings.controller.spec.ts
@@ -18,7 +18,10 @@ describe('RatingsController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(require('../../auth/keycloak-auth.guard').KeycloakAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<RatingsController>(RatingsController);
     service = module.get<RatingsService>(RatingsService);

--- a/backend/src/modules/ratings/rating.entity.ts
+++ b/backend/src/modules/ratings/rating.entity.ts
@@ -1,12 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Unique } from 'typeorm';
+import { Entity, Column, ManyToOne, Unique } from 'typeorm';
+import { TenantEntity } from '../common/tenant.entity';
 import { Player } from '../players/player.entity';
 import { Match } from '../matches/match.entity';
 
 @Entity('rating')
 @Unique(['player', 'match'])
-export class Rating {
-  @PrimaryGeneratedColumn('uuid')
-  id!: string;
+export class Rating extends TenantEntity {
 
   @Column('int')
   score!: number;

--- a/backend/src/modules/ratings/ratings.controller.ts
+++ b/backend/src/modules/ratings/ratings.controller.ts
@@ -6,7 +6,7 @@ import {
   ParseUUIDPipe,
   UseGuards,
 } from '@nestjs/common';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { KeycloakAuthGuard } from '../auth/keycloak-auth.guard';
 import { CreateRatingDto } from './dto/create-rating.dto';
 import { RatingsService } from './ratings.service';
 import {
@@ -24,7 +24,7 @@ import {
 export class RatingsController {
   constructor(private readonly ratingsService: RatingsService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Post()
   @ApiOperation({ summary: 'Create rating for a match' })
   @ApiParam({ name: 'matchId', type: 'string' })

--- a/backend/src/modules/scouting/dto/create-scouted-player.dto.ts
+++ b/backend/src/modules/scouting/dto/create-scouted-player.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsOptional, IsInt } from 'class-validator';
+
+export class CreateScoutedPlayerDto {
+  @IsString()
+  name!: string;
+
+  @IsOptional()
+  @IsString()
+  position?: string;
+
+  @IsOptional()
+  @IsInt()
+  rating?: number;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/backend/src/modules/scouting/scouted-player.entity.ts
+++ b/backend/src/modules/scouting/scouted-player.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, Column } from 'typeorm';
+import { TenantEntity } from '../common/tenant.entity';
+
+@Entity('scouted_player')
+export class ScoutedPlayer extends TenantEntity {
+  @Column()
+  name!: string;
+
+  @Column({ nullable: true })
+  position?: string;
+
+  @Column('int', { default: 0 })
+  rating!: number;
+
+  @Column({ nullable: true })
+  notes?: string;
+}

--- a/backend/src/modules/scouting/scouting.controller.ts
+++ b/backend/src/modules/scouting/scouting.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Post, Body, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { ScoutingService } from './scouting.service';
+import { CreateScoutedPlayerDto } from './dto/create-scouted-player.dto';
+
+@Controller('scouting')
+export class ScoutingController {
+  constructor(private readonly service: ScoutingService) {}
+
+  @Post('players')
+  create(@Body() dto: CreateScoutedPlayerDto, @Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.service.create(dto, tenantId);
+  }
+
+  @Get('players')
+  findAll(@Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.service.findAll(tenantId);
+  }
+}

--- a/backend/src/modules/scouting/scouting.module.ts
+++ b/backend/src/modules/scouting/scouting.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScoutedPlayer } from './scouted-player.entity';
+import { ScoutingService } from './scouting.service';
+import { ScoutingController } from './scouting.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ScoutedPlayer])],
+  controllers: [ScoutingController],
+  providers: [ScoutingService],
+})
+export class ScoutingModule {}

--- a/backend/src/modules/scouting/scouting.service.ts
+++ b/backend/src/modules/scouting/scouting.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ScoutedPlayer } from './scouted-player.entity';
+
+@Injectable()
+export class ScoutingService {
+  constructor(
+    @InjectRepository(ScoutedPlayer)
+    private readonly repo: Repository<ScoutedPlayer>,
+  ) {}
+
+  create(data: Partial<ScoutedPlayer>, tenantId: string) {
+    const entity = this.repo.create({ ...data, tenantId });
+    return this.repo.save(entity);
+  }
+
+  findAll(tenantId: string) {
+    return this.repo.find({ where: { tenantId } });
+  }
+}

--- a/backend/src/modules/stats/__tests__/stats.controller.spec.ts
+++ b/backend/src/modules/stats/__tests__/stats.controller.spec.ts
@@ -15,7 +15,10 @@ describe('StatsController', () => {
           useValue: { getStats: jest.fn() },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(require('../../auth/keycloak-auth.guard').KeycloakAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<StatsController>(StatsController);
     service = module.get<StatsService>(StatsService);
@@ -24,18 +27,18 @@ describe('StatsController', () => {
   it('calls service to get monthly stats', async () => {
     (service.getStats as jest.Mock).mockResolvedValue([{ name: 'A', value: 1 }]);
 
-    const result = await controller.getStats('month');
+    const result = await controller.getStats('month', { tenantId: 't1' } as any);
 
-    expect(service.getStats).toHaveBeenCalledWith('month');
+    expect(service.getStats).toHaveBeenCalledWith('month', 't1');
     expect(result).toEqual([{ name: 'A', value: 1 }]);
   });
 
   it('calls service to get season stats', async () => {
     (service.getStats as jest.Mock).mockResolvedValue([{ name: 'A', value: 1 }]);
 
-    const result = await controller.getStats('season');
+    const result = await controller.getStats('season', { tenantId: 't1' } as any);
 
-    expect(service.getStats).toHaveBeenCalledWith('season');
+    expect(service.getStats).toHaveBeenCalledWith('season', 't1');
     expect(result).toEqual([{ name: 'A', value: 1 }]);
   });
 });

--- a/backend/src/modules/stats/__tests__/stats.service.spec.ts
+++ b/backend/src/modules/stats/__tests__/stats.service.spec.ts
@@ -35,7 +35,7 @@ describe('StatsService', () => {
       });
     });
 
-    const statsPromise = service.getStats('month');
+    const statsPromise = service.getStats('month', 't1');
 
     // allow pending microtasks to run so service triggers rating calls
     await Promise.resolve();
@@ -59,7 +59,7 @@ describe('StatsService', () => {
     ]);
     (ratingsService.averageForPlayer as jest.Mock).mockResolvedValue(5);
 
-    await service.getStats('month');
+    await service.getStats('month', 't1');
 
     const callArgs = (ratingsService.averageForPlayer as jest.Mock).mock.calls[0];
     expect(callArgs[1]).toBeInstanceOf(Date);
@@ -71,7 +71,7 @@ describe('StatsService', () => {
     ]);
     (ratingsService.averageForPlayer as jest.Mock).mockResolvedValue(5);
 
-    await service.getStats('season');
+    await service.getStats('season', 't1');
 
     const callArgs = (ratingsService.averageForPlayer as jest.Mock).mock.calls[0];
     expect(callArgs[1]).toBeUndefined();

--- a/backend/src/modules/stats/stats.controller.ts
+++ b/backend/src/modules/stats/stats.controller.ts
@@ -1,14 +1,16 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Controller, Get, Query, UseGuards, Req } from '@nestjs/common';
+import { KeycloakAuthGuard } from '../auth/keycloak-auth.guard';
 import { StatsService } from './stats.service';
+import { Request } from 'express';
 
 @Controller('stats')
 export class StatsController {
   constructor(private readonly statsService: StatsService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(KeycloakAuthGuard)
   @Get()
-  getStats(@Query('range') range: 'month' | 'season' = 'month') {
-    return this.statsService.getStats(range);
+  getStats(@Query('range') range: 'month' | 'season' = 'month', @Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.statsService.getStats(range, tenantId);
   }
 }

--- a/backend/src/modules/stats/stats.service.ts
+++ b/backend/src/modules/stats/stats.service.ts
@@ -14,8 +14,8 @@ export class StatsService {
     private ratingsService: RatingsService,
   ) {}
 
-  async getStats(range: 'month' | 'season'): Promise<StatItem[]> {
-    const players = await this.playersService.findAll();
+  async getStats(range: 'month' | 'season', tenantId?: string): Promise<StatItem[]> {
+    const players = await this.playersService.findAll(tenantId ?? '');
     const since =
       range === 'month'
         ? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)

--- a/backend/src/modules/tactics/dto/create-tactic.dto.ts
+++ b/backend/src/modules/tactics/dto/create-tactic.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsObject } from 'class-validator';
+
+export class CreateTacticDto {
+  @IsString()
+  name!: string;
+
+  @IsString()
+  formation!: string;
+
+  @IsObject()
+  positions!: Record<string, string>;
+}

--- a/backend/src/modules/tactics/tactic.entity.ts
+++ b/backend/src/modules/tactics/tactic.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, Column } from 'typeorm';
+import { TenantEntity } from '../common/tenant.entity';
+
+@Entity('tactic')
+export class Tactic extends TenantEntity {
+  @Column()
+  name!: string;
+
+  @Column()
+  formation!: string;
+
+  @Column('jsonb')
+  positions!: Record<string, string>; // playerId -> position
+}

--- a/backend/src/modules/tactics/tactics.controller.ts
+++ b/backend/src/modules/tactics/tactics.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Post, Body, Req } from '@nestjs/common';
+import { TacticsService } from './tactics.service';
+import { CreateTacticDto } from './dto/create-tactic.dto';
+import { Request } from 'express';
+
+@Controller('tactics')
+export class TacticsController {
+  constructor(private readonly tactics: TacticsService) {}
+
+  @Post()
+  create(@Body() dto: CreateTacticDto, @Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.tactics.create(dto, tenantId);
+  }
+
+  @Get()
+  findAll(@Req() req: Request) {
+    const tenantId = (req as any).tenantId as string;
+    return this.tactics.findAll(tenantId);
+  }
+}

--- a/backend/src/modules/tactics/tactics.module.ts
+++ b/backend/src/modules/tactics/tactics.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Tactic } from './tactic.entity';
+import { TacticsService } from './tactics.service';
+import { TacticsController } from './tactics.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tactic])],
+  controllers: [TacticsController],
+  providers: [TacticsService],
+})
+export class TacticsModule {}

--- a/backend/src/modules/tactics/tactics.service.ts
+++ b/backend/src/modules/tactics/tactics.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tactic } from './tactic.entity';
+
+@Injectable()
+export class TacticsService {
+  constructor(
+    @InjectRepository(Tactic) private tacticsRepo: Repository<Tactic>,
+  ) {}
+
+  create(data: Partial<Tactic>, tenantId: string) {
+    const tactic = this.tacticsRepo.create({ ...data, tenantId });
+    return this.tacticsRepo.save(tactic);
+  }
+
+  findAll(tenantId: string) {
+    return this.tacticsRepo.find({ where: { tenantId } });
+  }
+}

--- a/backend/test/auth.e2e.spec.ts
+++ b/backend/test/auth.e2e.spec.ts
@@ -1,3 +1,8 @@
+process.env.DATABASE_URL = 'dummy';
+process.env.JWT_SECRET = 'testsecret';
+process.env.IA_SERVICE_URL = 'http://localhost';
+process.env.RABBITMQ_URL = 'amqp://localhost';
+
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -18,10 +23,6 @@ describeOrSkip('AuthModule (e2e)', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
-    process.env.DATABASE_URL = 'dummy';
-    process.env.JWT_SECRET = 'testsecret';
-    process.env.IA_SERVICE_URL = 'http://localhost';
-    process.env.RABBITMQ_URL = 'amqp://localhost';
 
     const moduleRef = await Test.createTestingModule({
       imports: [

--- a/backend/tsconfig.eslint.json
+++ b/backend/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts"],
   "exclude": []
 }

--- a/docs/multi-tenant-keycloak.md
+++ b/docs/multi-tenant-keycloak.md
@@ -1,0 +1,27 @@
+# Multi-tenant y Keycloak
+
+Este repositorio incorpora soporte básico multi-tenant y autenticación con Keycloak.
+
+## Multi-tenant
+
+- Se añadió la entidad base `TenantEntity` que incluye la columna `tenantId` para todas las tablas principales.
+- Se agregó `TenantMiddleware` que lee `X-Tenant-ID` de la cabecera y lo asigna a la petición.
+- Los módulos de jugadores y partidos aplican filtros por `tenantId`.
+- Nueva migración `AddTenantId1747088295099` añade la columna a las tablas existentes.
+
+## Keycloak
+
+- Se integró el paquete `nest-keycloak-connect`.
+- Nuevo módulo `KeycloakModule` configura el cliente según variables de entorno.
+- `KeycloakAuthGuard` reemplaza al guard de JWT en los controladores.
+
+Las variables de entorno necesarias son:
+
+```
+KEYCLOAK_URL=http://localhost:8080
+KEYCLOAK_REALM=sandei
+KEYCLOAK_CLIENT_ID=sandei-backend
+KEYCLOAK_CLIENT_SECRET=changeme
+```
+
+Para pruebas locales se puede continuar usando JWT si Keycloak no está disponible.


### PR DESCRIPTION
## Summary
- introduce TenantEntity and middleware for multi-tenant filtering
- integrate Keycloak authentication and update modules
- add tactics and scouting modules
- update tests and workflows
- document new features

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68530a20a6588330a53d14f0358fb2c3