### PR TITLE
Refactor: usar VITE_API_URL en llamadas API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3100

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -8,6 +8,8 @@ import {
 import { useNavigate } from 'react-router-dom';
 import api, { setAuthToken } from '@/services/api';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 interface AuthContextType {
   token: string | null;
   isAuthenticated: boolean;
@@ -26,7 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
 
   const login = useCallback(async (email: string, password: string) => {
-    const res = await api.post('/auth/login', { email, password });
+    const res = await api.post(`${API_URL}/api/auth/login`, { email, password });
     setToken(res.data.token);
     setAuthToken(res.data.token);
   }, []);

--- a/frontend/src/hooks/useFormations.ts
+++ b/frontend/src/hooks/useFormations.ts
@@ -1,10 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/services/api';
+
+const API_URL = import.meta.env.VITE_API_URL;
 import type { Formation, CreateFormationInput } from '@/types/formation';
 import { toast } from 'sonner';
 
 const fetchFormations = async (): Promise<Formation[]> => {
-  const res = await api.get('/formations');
+  const res = await api.get(`${API_URL}/api/formations`);
   return res.data;
 };
 
@@ -19,7 +21,7 @@ export const useCreateFormation = () => {
   const queryClient = useQueryClient();
   return useMutation<Formation, Error, CreateFormationInput>({
     mutationFn: async (data: CreateFormationInput) => {
-      const res = await api.post('/formations', data);
+      const res = await api.post(`${API_URL}/api/formations`, data);
       return res.data;
     },
     onSuccess: () => {

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -1,10 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/services/api';
+
+const API_URL = import.meta.env.VITE_API_URL;
 import { toast } from 'sonner';
 import type { Player, CreatePlayerInput } from '@/types/player';
 
 const fetchPlayers = async (): Promise<Player[]> => {
-  const res = await api.get('/players');
+  const res = await api.get(`${API_URL}/api/players`);
   return res.data;
 };
 
@@ -19,7 +21,7 @@ export const useCreatePlayer = () => {
   const queryClient = useQueryClient();
   return useMutation<Player, Error, CreatePlayerInput>({
     mutationFn: async (playerData: CreatePlayerInput) => {
-      const res = await api.post('/players', playerData);
+      const res = await api.post(`${API_URL}/api/players`, playerData);
       return res.data;
     },
     onSuccess: () => {
@@ -47,7 +49,7 @@ export const useUpdatePlayer = () => {
       id: string;
       data: Partial<CreatePlayerInput>;
     }) => {
-      const res = await api.put(`/players/${id}`, data);
+      const res = await api.put(`${API_URL}/api/players/${id}`, data);
       return res.data;
     },
     onSuccess: () => {
@@ -64,7 +66,7 @@ export const useDeletePlayer = () => {
   const queryClient = useQueryClient();
   return useMutation<void, Error, string>({
     mutationFn: async (id: string) => {
-      await api.delete(`/players/${id}`);
+      await api.delete(`${API_URL}/api/players/${id}`);
     },
     onSuccess: () => {
       toast.success('Jugador eliminado');

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,10 +1,9 @@
 import axios from 'axios';
 
-// Construye la baseURL usando VITE_API_URL y asegurando que termina con /api
-let baseURL = import.meta.env.VITE_API_URL?.replace(/\/$/, '') || '';
-if (!baseURL.endsWith('/api')) {
-  baseURL += '/api';
-}
+// Lee la URL base desde la variable de entorno
+export const API_URL = import.meta.env.VITE_API_URL?.replace(/\/$/, '') || '';
+
+const baseURL = API_URL;
 
 const api = axios.create({
   baseURL,

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,11 +1,17 @@
 import api from './api';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 export async function login(email: string, password: string) {
-  const res = await api.post('/auth/login', { email, password });
+  const res = await api.post(`${API_URL}/api/auth/login`, { email, password });
   return res.data;
 }
 
 export async function register(name: string, email: string, password: string) {
-  const res = await api.post('/auth/register', { name, email, password });
+  const res = await api.post(`${API_URL}/api/auth/register`, {
+    name,
+    email,
+    password,
+  });
   return res.data;
 }

--- a/frontend/src/services/demo.ts
+++ b/frontend/src/services/demo.ts
@@ -1,5 +1,7 @@
 import api from './api';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 export async function createDemoData() {
-  await api.post('/demo');
+  await api.post(`${API_URL}/api/demo`);
 }

--- a/frontend/src/services/formations.ts
+++ b/frontend/src/services/formations.ts
@@ -1,14 +1,16 @@
 import api from './api';
 
+const API_URL = import.meta.env.VITE_API_URL;
+
 export async function createFormation(data: {
   name: string;
   description?: string;
 }) {
-  const res = await api.post('/formations', data);
+  const res = await api.post(`${API_URL}/api/formations`, data);
   return res.data;
 }
 
 export async function getFormations() {
-  const res = await api.get('/formations');
+  const res = await api.get(`${API_URL}/api/formations`);
   return res.data;
 }

--- a/frontend/src/services/matches.ts
+++ b/frontend/src/services/matches.ts
@@ -1,7 +1,9 @@
 import api from './api';
+
+const API_URL = import.meta.env.VITE_API_URL;
 import type { Match } from '../types/match';
 
 export async function getMatches(): Promise<Match[]> {
-  const res = await api.get('/matches');
+  const res = await api.get(`${API_URL}/api/matches`);
   return res.data;
 }

--- a/frontend/src/services/playerService.ts
+++ b/frontend/src/services/playerService.ts
@@ -1,21 +1,23 @@
 import api from './api';
+
+const API_URL = import.meta.env.VITE_API_URL;
 import type { CreatePlayerInput, Player } from '../types/player';
 
 export async function createPlayer(data: CreatePlayerInput): Promise<Player> {
-  const res = await api.post('/players', data);
+  const res = await api.post(`${API_URL}/api/players`, data);
   return res.data;
 }
 export async function deletePlayer(id: string) {
-  await api.delete(`/players/${id}`);
+  await api.delete(`${API_URL}/api/players/${id}`);
 }
 export async function updatePlayer(
   id: string,
   data: Partial<CreatePlayerInput>,
 ): Promise<Player> {
-  const res = await api.put(`/players/${id}`, data);
+  const res = await api.put(`${API_URL}/api/players/${id}`, data);
   return res.data;
 }
 export async function getPlayers(): Promise<Player[]> {
-  const res = await api.get('/players');
+  const res = await api.get(`${API_URL}/api/players`);
   return res.data;
 }

--- a/frontend/src/services/stats.ts
+++ b/frontend/src/services/stats.ts
@@ -1,7 +1,9 @@
 import api from './api';
+
+const API_URL = import.meta.env.VITE_API_URL;
 import type { StatItem } from '@/types/stats';
 
 export async function getStats(range: 'month' | 'season'): Promise<StatItem[]> {
-  const res = await api.get(`/stats`, { params: { range } });
+  const res = await api.get(`${API_URL}/api/stats`, { params: { range } });
   return res.data;
 }


### PR DESCRIPTION
## Summary
- update axios setup to read API URL from env
- prepend `/api` path using `API_URL` in all frontend service calls

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm test --silent` in backend *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_b_686986d90e348330ac3a393aa93c50ea