### PR TITLE
Fix API URL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Servicios adicionales como MongoDB, Redis y RabbitMQ se utilizan para tareas int
 
 ## Instalación y ejecución local
 1. Clona este repositorio.
-2. Copia cada archivo `.env.example` a `.env` en la raíz, `backend/`, `frontend/` e `ia-service/` y completa los valores necesarios.
+2. Copia cada archivo `.env.example` a `.env` en la raíz, `backend/`, `frontend/` e `ia-service/` y completa los valores necesarios. En particular, asegúrate de que `frontend/.env` defina `VITE_API_URL` apuntando al backend, por ejemplo:
+   ```ini
+   VITE_API_URL=http://localhost:3100
+   ```
 3. Levanta todo con Docker Compose:
 ```bash
 ./run_local.sh
@@ -47,6 +50,15 @@ cd ../ia-service && pip install -r requirements.txt && uvicorn app.main:app --re
 - El frontend estará disponible en [http://localhost:5173](http://localhost:5173).
 - Registra usuarios y carga jugadores desde la interfaz.
 - Consulta el módulo de IA para obtener tácticas y predicciones de partido.
+
+### Verificación rápida
+Una vez configurado el entorno, levanta los contenedores:
+
+```bash
+docker-compose -f infra/docker-compose.yml up --build -d
+```
+
+Luego abre la aplicación y prueba registrarte o iniciar sesión. Las peticiones deberían dirigirse a `http://localhost:3100` sin mostrar rutas `undefined/api/...`.
 
 ## Testing y CI
 - Backend: `npm run test`

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3100

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -6,9 +6,7 @@ import {
   useMemo,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
-import api, { setAuthToken } from '@/services/api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL, setAuthToken } from '@/services/api';
 
 interface AuthContextType {
   token: string | null;

--- a/frontend/src/hooks/useFormations.ts
+++ b/frontend/src/hooks/useFormations.ts
@@ -1,7 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import api from '@/services/api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from '@/services/api';
 import type { Formation, CreateFormationInput } from '@/types/formation';
 import { toast } from 'sonner';
 

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -1,7 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import api from '@/services/api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from '@/services/api';
 import { toast } from 'sonner';
 import type { Player, CreatePlayerInput } from '@/types/player';
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,6 +1,4 @@
-import api from './api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from './api';
 
 export async function login(email: string, password: string) {
   const res = await api.post(`${API_URL}/api/auth/login`, { email, password });

--- a/frontend/src/services/demo.ts
+++ b/frontend/src/services/demo.ts
@@ -1,6 +1,4 @@
-import api from './api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from './api';
 
 export async function createDemoData() {
   await api.post(`${API_URL}/api/demo`);

--- a/frontend/src/services/formations.ts
+++ b/frontend/src/services/formations.ts
@@ -1,6 +1,4 @@
-import api from './api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from './api';
 
 export async function createFormation(data: {
   name: string;

--- a/frontend/src/services/matches.ts
+++ b/frontend/src/services/matches.ts
@@ -1,6 +1,4 @@
-import api from './api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from './api';
 import type { Match } from '../types/match';
 
 export async function getMatches(): Promise<Match[]> {

--- a/frontend/src/services/playerService.ts
+++ b/frontend/src/services/playerService.ts
@@ -1,6 +1,4 @@
-import api from './api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from './api';
 import type { CreatePlayerInput, Player } from '../types/player';
 
 export async function createPlayer(data: CreatePlayerInput): Promise<Player> {

--- a/frontend/src/services/stats.ts
+++ b/frontend/src/services/stats.ts
@@ -1,6 +1,4 @@
-import api from './api';
-
-const API_URL = import.meta.env.VITE_API_URL;
+import api, { API_URL } from './api';
 import type { StatItem } from '@/types/stats';
 
 export async function getStats(range: 'month' | 'season'): Promise<StatItem[]> {


### PR DESCRIPTION
## Summary
- add missing `.env` in frontend with `VITE_API_URL`
- import `API_URL` from a single axios client
- document env var setup and quick verification

## Testing
- `npm run lint`
- `npm run test` *(fails: 2 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68698b85381c8330a881cb5c19e0e82d