### PR TITLE
Minor fixes and tenant migration

### DIFF
--- a/backend/src/migrations/1747088295099-AddTenantId.ts
+++ b/backend/src/migrations/1747088295099-AddTenantId.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddTenantId1747088295099 implements MigrationInterface {
+  name = 'AddTenantId1747088295099'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "players" ADD "tenantId" varchar NOT NULL DEFAULT 'default'`);
+    await queryRunner.query(`ALTER TABLE "match" ADD "tenantId" varchar NOT NULL DEFAULT 'default'`);
+    await queryRunner.query(`ALTER TABLE "rating" ADD "tenantId" varchar NOT NULL DEFAULT 'default'`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "rating" DROP COLUMN "tenantId"`);
+    await queryRunner.query(`ALTER TABLE "match" DROP COLUMN "tenantId"`);
+    await queryRunner.query(`ALTER TABLE "players" DROP COLUMN "tenantId"`);
+  }
+}
+

--- a/frontend/src/context/useAuth.ts
+++ b/frontend/src/context/useAuth.ts
@@ -1,12 +1,15 @@
 import { useContext } from 'react';
 import { AuthContext } from './AuthContext';
 
+/**
+ * Obtiene el contexto de autenticación de forma segura.
+ * Lanza un error descriptivo si el hook se usa fuera del `AuthProvider`.
+ */
 export function useAuth() {
-  return {
-    user: { email: 'dev@sandei.app', name: 'Dev User' },
-    token: 'mock-token',
-    isAuthenticated: true,
-    login: async () => {}, // nunca falla
-    logout: () => {},
-  };
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
 }
+


### PR DESCRIPTION
## Summary
- fix `useAuth` to correctly read the context instead of returning mock data
- add missing migration to include `tenantId` in main tables

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686bcb7cc85883309f67b11b97b5ee7e