### PR TITLE
Fix hooks for players and formations

### DIFF
--- a/frontend/src/hooks/useFormations.ts
+++ b/frontend/src/hooks/useFormations.ts
@@ -8,25 +8,12 @@ const fetchFormations = async (): Promise<Formation[]> => {
   return res.data;
 };
 
-export const useFormations = () => {
-  // MOCK: Devuelve formaciones de ejemplo
-  return {
-    data: [
-      { id: '1', name: '4-3-3', description: 'Ofensiva' },
-      { id: '2', name: '4-4-2', description: 'Clásica' },
-    ],
-    isLoading: false,
-    error: null,
-  };
-};
+export const useFormations = () =>
+  useQuery<Formation[]>({
+    queryKey: ['formations'],
+    queryFn: fetchFormations,
+  });
 
-<<<<<<< HEAD
-export const useCreateFormation = () => ({
-  mutateAsync: async () => {},
-  isLoading: false,
-  error: null,
-});
-=======
 export const useCreateFormation = () => {
   const queryClient = useQueryClient();
   return useMutation<Formation, Error, CreateFormationInput>({
@@ -43,4 +30,41 @@ export const useCreateFormation = () => {
     },
   });
 };
->>>>>>> 4d6d44ccf4fe5e57a7dd184a4c8d6d3a5f9df5eb
+
+export const useUpdateFormation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    Formation,
+    Error,
+    { id: string; data: Partial<CreateFormationInput> }
+  >({
+    mutationFn: async ({ id, data }) => {
+      const res = await api.put(`${API_URL}/api/formations/${id}`, data);
+      return res.data;
+    },
+    onSuccess: () => {
+      toast.success('Formaci\u00f3n actualizada');
+      queryClient.invalidateQueries({ queryKey: ['formations'] });
+    },
+    onError: () => {
+      // handled globally
+    },
+  });
+};
+
+export const useDeleteFormation = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: async (id: string) => {
+      await api.delete(`${API_URL}/api/formations/${id}`);
+    },
+    onSuccess: () => {
+      toast.success('Formaci\u00f3n eliminada');
+      queryClient.invalidateQueries({ queryKey: ['formations'] });
+    },
+    onError: () => {
+      // handled globally
+    },
+  });
+};
+

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -8,37 +8,12 @@ const fetchPlayers = async (): Promise<Player[]> => {
   return res.data;
 };
 
-export const usePlayers = () => {
-  // MOCK: Devuelve jugadores de ejemplo
-  return {
-    data: [
-      { id: '1', name: 'Lionel Messi', stats: { goals: 10, assists: 5 } },
-      { id: '2', name: 'Cristiano Ronaldo', stats: { goals: 8, assists: 3 } },
-    ],
-    isLoading: false,
-    error: null,
-  };
-};
+export const usePlayers = () =>
+  useQuery<Player[]>({
+    queryKey: ['players'],
+    queryFn: fetchPlayers,
+  });
 
-<<<<<<< HEAD
-export const useCreatePlayer = () => ({
-  mutateAsync: async () => {},
-  isLoading: false,
-  error: null,
-});
-
-export const useDeletePlayer = () => ({
-  mutateAsync: async () => {},
-  isLoading: false,
-  error: null,
-});
-
-export const useUpdatePlayer = () => ({
-  mutateAsync: async () => {},
-  isLoading: false,
-  error: null,
-});
-=======
 export const useCreatePlayer = () => {
   const queryClient = useQueryClient();
   return useMutation<Player, Error, CreatePlayerInput>({
@@ -100,4 +75,3 @@ export const useDeletePlayer = () => {
     },
   });
 };
->>>>>>> 4d6d44ccf4fe5e57a7dd184a4c8d6d3a5f9df5eb

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import { useAuth } from '@/context/useAuth';
 import { useNavigate, Link } from 'react-router-dom';
-import { motion } from 'framer-motion';
 import { usePlayers } from '@/hooks/usePlayers';
 import { useMatches } from '@/hooks/useMatches';
 import { useMemo, useCallback, useState, useRef, useEffect } from 'react';


### PR DESCRIPTION
## Summary
- implement React Query hooks for players and formations
- resolve leftover merge markers
- clean unused import in `Dashboard.tsx`
- run lint and tests

## Testing
- `npm run lint`
- `npm run test` *(fails: 5 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c58b3c4833091c2941e8b6d996b