### PR TITLE
Implement simple Players component

### DIFF
--- a/frontend/src/components/Players.test.tsx
+++ b/frontend/src/components/Players.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import Players from './Players';
+
+vi.mock('@/hooks/usePlayers', () => ({
+  usePlayers: () => ({ data: [{ id: '1', name: 'John' }], isLoading: false, error: null }),
+}));
+
+describe('Players component', () => {
+  it('renders list of players', () => {
+    render(<Players />);
+    expect(screen.getByText('John')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Players.tsx
+++ b/frontend/src/components/Players.tsx
@@ -1,3 +1,23 @@
-// TODO: implement players component
+import React from 'react';
+import { usePlayers } from '@/hooks/usePlayers';
+function Players() {
+  const { data: players = [], isLoading, error } = usePlayers();
 
-// ...existing code...
+  if (isLoading) {
+    return <p>Loading players...</p>;
+  }
+
+  if (error) {
+    return <p>Error loading players</p>;
+  }
+
+  return (
+    <ul>
+      {players.map((p) => (
+        <li key={p.id}>{p.name}</li>
+      ))}
+    </ul>
+  );
+}
+
+export default Players;


### PR DESCRIPTION
## Summary
- create a minimal `Players` component that lists player names
- add a small test for this component

## Testing
- `npm run test` *(fails: 5 failed, 15 passed)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c58f5c083309e9c3957a2cf2499