### PR TITLE
Fix IA router imports in tests

### DIFF
--- a/ia-service/tests/test_analyze_performance.py
+++ b/ia-service/tests/test_analyze_performance.py
@@ -1,7 +1,7 @@
 import asyncio
 from app.schemas import PerformanceRequest
 from app.config import settings
-from app.routers.ia_router import analyze_performance
+from app.routers.ia import analyze_performance
 
 
 class DummyAsyncClient:
@@ -10,13 +10,16 @@ class DummyAsyncClient:
 
 
 class DummyResponse:
-    async def json(self):
+    def raise_for_status(self):
+        pass
+
+    def json(self):
         return {"analysis": "ok"}
 
 
 def test_analyze_performance(monkeypatch):
     # Simulamos que la API key está configurada
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', 'test-key')
+    monkeypatch.setattr(settings, 'openai_api_key', 'test-key')
 
     payload = PerformanceRequest(ratings=[{"player": "John", "score": 7}])
 

--- a/ia-service/tests/test_detect_errors.py
+++ b/ia-service/tests/test_detect_errors.py
@@ -1,7 +1,7 @@
 import asyncio
 from app.schemas import ErrorDetectionRequest
 from app.config import settings
-from app.routers.ia_router import detect_errors
+from app.routers.ia import detect_errors
 
 
 class DummyAsyncClient:
@@ -10,13 +10,16 @@ class DummyAsyncClient:
 
 
 class DummyResponse:
-    async def json(self):
+    def raise_for_status(self):
+        pass
+
+    def json(self):
         return {"report": "ok"}
 
 
 def test_detect_errors(monkeypatch):
     # Simulamos que la API key está configurada
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', 'test-key')
+    monkeypatch.setattr(settings, 'openai_api_key', 'test-key')
 
     payload = ErrorDetectionRequest(lineup=["A", "B"], formation=None)
 

--- a/ia-service/tests/test_no_api_key.py
+++ b/ia-service/tests/test_no_api_key.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from fastapi import HTTPException
 from app.config import settings
-from app.routers.ia_router import (
+from app.routers.ia import (
     analyze_performance,
     predict_match,
     detect_errors,
@@ -13,8 +13,8 @@ from app.schemas import (
     PerformanceRequest,
     MatchPredictionRequest,
     ErrorDetectionRequest,
-    LineupSuggestionRequest,
-    TacticSuggestionRequest,
+    LineupRequest,
+    TacticsRequest,
 )
 
 
@@ -24,13 +24,16 @@ class DummyAsyncClient:
 
 
 class DummyResponse:
-    async def json(self):
+    def raise_for_status(self):
+        pass
+
+    def json(self):
         return {"result": "dummy"}
 
 
 def test_analyze_performance_no_key(monkeypatch):
     # Simulamos que la API key no está configurada
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', None)
+    monkeypatch.setattr(settings, 'openai_api_key', None)
     payload = PerformanceRequest(ratings=[{"player": "John", "score": 7}])
 
     with pytest.raises(HTTPException):
@@ -39,15 +42,15 @@ def test_analyze_performance_no_key(monkeypatch):
 
 
 def test_predict_match_no_key(monkeypatch):
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', None)
-    payload = MatchPredictionRequest(lineups=[["A", "B"]])
+    monkeypatch.setattr(settings, 'openai_api_key', None)
+    payload = MatchPredictionRequest(home_team=["A"], away_team=["B"])
 
     with pytest.raises(HTTPException):
         asyncio.run(predict_match(payload, DummyAsyncClient()))
 
 
 def test_detect_errors_no_key(monkeypatch):
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', None)
+    monkeypatch.setattr(settings, 'openai_api_key', None)
     payload = ErrorDetectionRequest(lineup=["A", "B"], formation=None)
 
     with pytest.raises(HTTPException):
@@ -55,16 +58,16 @@ def test_detect_errors_no_key(monkeypatch):
 
 
 def test_suggest_lineup_no_key(monkeypatch):
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', None)
-    payload = LineupSuggestionRequest(players=["A", "B"], formation="4-4-2")
+    monkeypatch.setattr(settings, 'openai_api_key', None)
+    payload = LineupRequest(players=["A", "B"], formation="4-4-2")
 
     with pytest.raises(HTTPException):
         asyncio.run(suggest_lineup(payload, DummyAsyncClient()))
 
 
 def test_suggest_tactics_no_key(monkeypatch):
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', None)
-    payload = TacticSuggestionRequest(players=["A", "B"], formation="4-4-2")
+    monkeypatch.setattr(settings, 'openai_api_key', None)
+    payload = TacticsRequest(players=["A", "B"], style=None)
 
     with pytest.raises(HTTPException):
         asyncio.run(suggest_tactics(payload, DummyAsyncClient()))

--- a/ia-service/tests/test_predict_match.py
+++ b/ia-service/tests/test_predict_match.py
@@ -21,14 +21,14 @@ class DummyAsyncClient:
 # Inyectamos DummyAsyncClient en lugar de httpx.AsyncClient
 sys.modules['httpx'] = types.SimpleNamespace(AsyncClient=DummyAsyncClient)
 
-from app.routers.ia_router import predict_match
+from app.routers.ia import predict_match
 from app.schemas import MatchPredictionRequest
 from app.config import settings
 
 
 def test_predict_match(monkeypatch):
     # Simulamos que la API key está configurada
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', 'test-key')
+    monkeypatch.setattr(settings, 'openai_api_key', 'test-key')
 
     payload = MatchPredictionRequest(home_team=['A'], away_team=['B'])
 

--- a/ia-service/tests/test_suggest_tactics.py
+++ b/ia-service/tests/test_suggest_tactics.py
@@ -21,14 +21,14 @@ class DummyAsyncClient:
 # Inyectamos el stub como httpx
 sys.modules['httpx'] = types.SimpleNamespace(AsyncClient=DummyAsyncClient)
 
-from app.routers.ia_router import suggest_tactics
+from app.routers.ia import suggest_tactics
 from app.schemas import TacticsRequest
 from app.config import settings
 
 
 def test_suggest_tactics(monkeypatch):
     # Simulamos que la API key está configurada
-    monkeypatch.setattr(settings, 'OPENAI_API_KEY', 'test-key')
+    monkeypatch.setattr(settings, 'openai_api_key', 'test-key')
 
     payload = TacticsRequest(players=["John"], style=None)
 


### PR DESCRIPTION
## Summary
- update `ia-service` tests to import from new router module
- sync schema names in tests with `app/schemas.py`
- adjust dummy responses for changed OpenAI client
- run `pytest`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: fastapi.exceptions.HTTPException)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c5dca388330ac099db7f0a9d7c0