### PR TITLE
Remove root env file and document setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_API_URL=http://localhost:3100

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Servicios adicionales como MongoDB, Redis y RabbitMQ se utilizan para tareas int
 
 ## Instalación y ejecución local
 1. Clona este repositorio.
-2. Copia cada archivo `.env.example` a `.env` en la raíz, `backend/`, `frontend/` e `ia-service/` y completa los valores necesarios. En particular, asegúrate de que `frontend/.env` defina `VITE_API_URL` apuntando al backend, por ejemplo:
+2. Copia el archivo `.env.example` de la raíz a `.env` y repite lo mismo en `backend/`, `frontend/` e `ia-service/`. Completa luego los valores necesarios. En particular, verifica que `frontend/.env` defina `VITE_API_URL` apuntando al backend, por ejemplo:
    ```ini
    VITE_API_URL=http://localhost:3100
    ```


### PR DESCRIPTION
## Summary
- delete `.env` from git
- document copying `.env.example` to `.env` in README

## Testing
- `npm test` within `backend`
- `npm test` within `frontend` *(fails: 5 failed)*
- `pytest` within `ia-service` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_686d3c61903c83308903d3df43d2670e