### PR TITLE
Fix duplicates in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,5 @@ infra/.env
 node_modules/
 **/node_modules/
 *.env
-node_modules/
 frontend/node_modules/
 backend/node_modules/
-SandeiApp.git/


### PR DESCRIPTION
## Summary
- remove duplicate `node_modules/` entry
- drop stray `SandeiApp.git/` ignore rule

## Testing
- `npm run test` in `backend` *(fails: jest not found)*
- `npm run test` in `frontend` *(fails: vitest not found)*
- `pytest` in `ia-service` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_b_6870ff3d43c88330bd9cef2a6628aee4