### PR TITLE
Update NotFound test for login link

### DIFF
--- a/frontend/src/pages/NotFound.test.tsx
+++ b/frontend/src/pages/NotFound.test.tsx
@@ -11,6 +11,6 @@ describe('NotFound page', () => {
       </MemoryRouter>,
     );
     expect(screen.getByText(/Página no encontrada/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Ir al login/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Login/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- fix the login link assertion in `NotFound.test.tsx`

## Testing
- `npm run test` in `backend` (passed)
- `npm run test` in `frontend` *(fails: 5 failed, 24 passed)*
- `pytest` in `ia-service` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_b_687a952d39e883308fb3b6957e717dae