### PR TITLE
Add waitFor for API call

### DIFF
--- a/frontend/src/hooks/useFormations.test.tsx
+++ b/frontend/src/hooks/useFormations.test.tsx
@@ -4,11 +4,9 @@ import { vi } from 'vitest';
 import { useFormations } from './useFormations';
 import api from '@/services/api';
 
-vi.mock('@/services/api', () => ({
-  default: { get: vi.fn() },
-}));
+vi.mock('@/services/api');
 
-const mockedApi = api as unknown as { get: ReturnType<typeof vi.fn> };
+const mockedApi = vi.mocked(api);
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const client = new QueryClient({
@@ -25,6 +23,7 @@ describe('useFormations', () => {
   it('fetch de formaciones exitoso', async () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', name: '4-4-2' }] });
     const { result } = renderHook(() => useFormations(), { wrapper });
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual([{ id: '1', name: '4-4-2' }]);
   });

--- a/frontend/src/hooks/usePlayers.test.tsx
+++ b/frontend/src/hooks/usePlayers.test.tsx
@@ -4,11 +4,9 @@ import { vi } from 'vitest';
 import { usePlayers } from './usePlayers';
 import api from '@/services/api';
 
-vi.mock('@/services/api', () => ({
-  default: { get: vi.fn() },
-}));
+vi.mock('@/services/api');
 
-const mockedApi = api as unknown as { get: ReturnType<typeof vi.fn> };
+const mockedApi = vi.mocked(api);
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
   const client = new QueryClient({
@@ -25,6 +23,7 @@ describe('usePlayers', () => {
   it('fetch de jugadores exitoso', async () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', name: 'John' }] });
     const { result } = renderHook(() => usePlayers(), { wrapper });
+    await waitFor(() => expect(mockedApi.get).toHaveBeenCalled());
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual([{ id: '1', name: 'John' }]);
   });


### PR DESCRIPTION
## Summary
- add explicit waitFor on mocked API call before asserting success status in hook tests

## Testing
- `npx vitest run src/hooks/usePlayers.test.tsx src/hooks/useFormations.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_687a952aa67c8330916befbafdf03401