### PR TITLE
Fix login integration label

### DIFF
--- a/frontend/src/pages/Login.integration.test.tsx
+++ b/frontend/src/pages/Login.integration.test.tsx
@@ -27,7 +27,7 @@ describe('Login integration', () => {
     );
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
     fireEvent.change(screen.getByLabelText('Contraseña'), { target: { value: '123456' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Ingresar' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Iniciar Sesión' }));
 
     await waitFor(() => expect(loginMock).toHaveBeenCalledWith('test@example.com', '123456'));
     expect(navigateMock).toHaveBeenCalledWith('/dashboard');
@@ -44,7 +44,7 @@ describe('Login integration', () => {
     );
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
     fireEvent.change(screen.getByLabelText('Contraseña'), { target: { value: '123456' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Ingresar' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Iniciar Sesión' }));
 
     await waitFor(() => expect(loginMock).toHaveBeenCalled());
     expect(navigateMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- update the expected login button label in Login.integration.test.tsx

## Testing
- `npm test --silent` *(fails: Test Files 4 failed | 16 passed)*

------
https://chatgpt.com/codex/tasks/task_b_687a952817708330b6459964a685c53b